### PR TITLE
add: エラーメッセージのパーシャルを作成 #14

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,41 +1,41 @@
 
 <div class="container mx-auto w-[540px] px-10 py-5">
-    <h1 class="text-5xl font-bold text-center mb-10">新規登録</h1>
+  <h1 class="text-5xl font-bold text-center mb-10">新規登録</h1>
 
-    <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-      <%= render "devise/shared/error_messages", resource: resource %>
-      <div class="field">
-        <%= f.label :account %><br />
-        <%= f.text_field :account, autofocus: true, autocomplete: "account", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: "半角英数4文字以上" %>
-      </div>
-      <div class="field">
-        <%= f.label :name %><br />
-        <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: "10文字以下" %>
-      </div>
-      <div class="field">
-        <%= f.label :email %><br />
-        <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: "メールアドレスを入力" %>
-      </div>
-
-      <div class="field">
-        <%= f.label :password %>
-        <% if @minimum_password_length %>
-        <em>(<%= @minimum_password_length %> characters minimum)</em>
-        <% end %><br />
-        <%= f.password_field :password, autocomplete: "new-password", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: "6文字以上" %>
-      </div>
-
-      <div class="field">
-        <%= f.label :password_confirmation %><br />
-        <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: "パスワードをもう一度入力" %>
-      </div>
-
-      <div class="actions">
-        <%= f.submit "登録する", class: "btn btn-secondary mb-6 w-full mx-auto mt-2" %>
-      </div>
-    <% end %>
-
-    <div class="text-center">
-      <%= render "devise/shared/links" %>
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
+    <div class="field">
+      <%= f.label :account %><br />
+      <%= f.text_field :account, autofocus: true, autocomplete: "account", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: "半角英数4文字以上" %>
     </div>
+    <div class="field">
+      <%= f.label :name %><br />
+      <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: "10文字以下" %>
+    </div>
+    <div class="field">
+      <%= f.label :email %><br />
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: "メールアドレスを入力" %>
+    </div>
+
+    <div class="field">
+      <%= f.label :password %>
+      <% if @minimum_password_length %>
+        <em>(<%= @minimum_password_length %> characters minimum)</em>
+      <% end %><br />
+      <%= f.password_field :password, autocomplete: "new-password", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: "6文字以上" %>
+    </div>
+
+    <div class="field">
+      <%= f.label :password_confirmation %><br />
+      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: "パスワードをもう一度入力" %>
+    </div>
+
+    <div class="actions">
+      <%= f.submit "登録する", class: "btn btn-secondary mb-6 w-full mx-auto mt-2" %>
+    </div>
+  <% end %>
+
+  <div class="text-center">
+    <%= render "devise/shared/links" %>
+  </div>
 </div>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,12 +1,23 @@
 <% if resource.errors.any? %>
   <div id="error_explanation" data-turbo-cache="false">
-    <h2>
+    <div role="alert" class="alert alert-error">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        class="h-6 w-6 shrink-0 stroke-current"
+        fill="none"
+        viewBox="0 0 24 24">
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,
                  resource: resource.class.model_name.human.downcase)
        %>
-    </h2>
-    <ul>
+    </div>
+    <ul class="text-error px-10 list-disc">
       <% resource.errors.full_messages.each do |message| %>
         <li><%= message %></li>
       <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,6 +24,13 @@
         <%= render 'layouts/header' %>
       </header>
       <main class="flex-grow">
+        <% flash.each do |message_type, message| %>
+          <% if flash[:alert] %>
+            <div class="alert alert-warning"><%= message %></div>
+          <% else %>
+            <div class="alert alert-<%= message_type %>"><%= message %></div>
+          <% end %>
+        <% end %>
         <%= yield %>
       </main>
       <footer class="footer bg-[#A6ABBD] text-[#424656] items-center p-4 sticky bottom-0">

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,12 @@
+<% if object.errors.any? %>
+  <div id="error_explanation">
+    <div class="alert alert-error">
+      The form contains <%= pluralize(object.errors.count, "error") %>.
+    </div>
+    <ul class="text-error px-10 list-disc">
+    <% object.errors.full_messages.each do |msg| %>
+      <li><%= msg %></li>
+    <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/static/home.html.erb
+++ b/app/views/static/home.html.erb
@@ -1,6 +1,9 @@
 <div>
   <h1 class="text-4xl text-green-700 font-semibold underline">Static#home</h1>
   <p>Find me in app/views/static/home.html.erb</p>
+  <% if user_signed_in? %>
+    <%= link_to 'ログアウトする', destroy_user_session_path, data: { turbo_method: :delete } %>
+  <% end %>
 </div>
 
 <button class="btn" onclick="my_modal_1.showModal()">open modal</button>

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,6 @@ module Myapp
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    config.action_view.field_error_proc = Proc.new { |html_tag, instance| html_tag }
   end
 end


### PR DESCRIPTION
close #14 エラーメッセージの作成
- [x] app/views/shared/_error_messages.html.erbを作成、編集する。
- [x] app/views/devise/shared/_error_messages.html.erbを編集。

追加
- [x] app/config/application.rbにfield_with_errorsの自動挿入を防ぐ記述を追加
  - エラーメッセージが表示されたときのレイアウト崩れを防ぐため
- [x] app/views/layouts/application.html.erbを編集
  - 先にフラッシュメッセージだけ表示できるようにしてあります（ログイン失敗時のエラー確認のため）。
    フラッシュメッセージは次のタスクでパーシャル作って実装します。
- [x] app/views/devise/registrations/new.html.erbの子要素が全体的に1行ずれてたのを修正。
- [x] ログアウトできないの不便なのでルートページにとりあえずでログアウトリンク置きました（issue#19で消します）。