### PR TITLE
管理画面の作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,3 +75,4 @@ gem 'ransack'
 gem 'csv'
 
 gem "administrate"
+gem "administrate-field-active_storage"

--- a/Gemfile
+++ b/Gemfile
@@ -73,3 +73,5 @@ gem 'active_hash'
 gem 'ransack'
 
 gem 'csv'
+
+gem "administrate"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,9 @@ GEM
       kaminari (~> 1.2.2)
       sassc-rails (~> 2.1)
       selectize-rails (~> 0.6)
+    administrate-field-active_storage (1.0.5)
+      administrate (>= 0.2.2)
+      rails (>= 7.0)
     ast (2.4.2)
     aws-eventstream (1.3.2)
     aws-partitions (1.1075.0)
@@ -412,6 +415,7 @@ DEPENDENCIES
   active_hash
   active_storage_validations
   administrate
+  administrate-field-active_storage
   aws-sdk-s3 (= 1.114.0)
   bootsnap
   brakeman

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,14 @@ GEM
       tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    administrate (0.20.1)
+      actionpack (>= 6.0, < 8.0)
+      actionview (>= 6.0, < 8.0)
+      activerecord (>= 6.0, < 8.0)
+      jquery-rails (~> 4.6.0)
+      kaminari (~> 1.2.2)
+      sassc-rails (~> 2.1)
+      selectize-rails (~> 0.6)
     ast (2.4.2)
     aws-eventstream (1.3.2)
     aws-partitions (1.1075.0)
@@ -160,9 +168,25 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     jmespath (1.6.2)
+    jquery-rails (4.6.0)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.10.2)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
     logger (1.6.6)
@@ -311,7 +335,16 @@ GEM
       ffi (~> 1.12)
       logger
     rubyzip (2.4.1)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     securerandom (0.4.1)
+    selectize-rails (0.12.6)
     selenium-webdriver (4.29.1)
       base64 (~> 0.2)
       logger (~> 1.4)
@@ -337,6 +370,7 @@ GEM
     tailwindcss-ruby (3.4.17-x86_64-darwin)
     tailwindcss-ruby (3.4.17-x86_64-linux)
     thor (1.3.2)
+    tilt (2.6.0)
     timeout (0.4.3)
     turbo-rails (2.0.13)
       actionpack (>= 7.1.0)
@@ -377,6 +411,7 @@ PLATFORMS
 DEPENDENCIES
   active_hash
   active_storage_validations
+  administrate
   aws-sdk-s3 (= 1.114.0)
   bootsnap
   brakeman

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,4 @@
 //= link_tree ../images
 //= link_directory ../stylesheets .css
 //= link_tree ../builds
+//= link administrate-field-active_storage/application.css

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -1,0 +1,21 @@
+# All Administrate controllers inherit from this
+# `Administrate::ApplicationController`, making it the ideal place to put
+# authentication logic or other before_actions.
+#
+# If you want to add pagination or other controller-level concerns,
+# you're free to overwrite the RESTful controller actions.
+module Admin
+  class ApplicationController < Administrate::ApplicationController
+    before_action :authenticate_admin
+
+    def authenticate_admin
+      # TODO Add authentication logic here.
+    end
+
+    # Override this value to specify the number of elements to display at a time
+    # on index pages. Defaults to 20.
+    # def records_per_page
+    #   params[:per_page] || 20
+    # end
+  end
+end

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -10,7 +10,7 @@ module Admin
 
     def authenticate_admin
       # TODO Add authentication logic here.
-      authenticate_user! unless user_signed_in?
+      authenticate_user!
       redirect_to root_path, alert: "権限がありません。" unless current_user&.admin?
     end
 

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -10,6 +10,8 @@ module Admin
 
     def authenticate_admin
       # TODO Add authentication logic here.
+      authenticate_user! unless user_signed_in?
+      redirect_to root_path, alert: "権限がありません。" unless current_user&.admin?
     end
 
     # Override this value to specify the number of elements to display at a time

--- a/app/controllers/admin/bookmarks_controller.rb
+++ b/app/controllers/admin/bookmarks_controller.rb
@@ -1,0 +1,46 @@
+module Admin
+  class BookmarksController < Admin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   super
+    #   send_foo_updated_email(requested_resource)
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # The result of this lookup will be available as `requested_resource`
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #   if current_user.super_admin?
+    #     resource_class
+    #   else
+    #     resource_class.with_less_stuff
+    #   end
+    # end
+
+    # Override `resource_params` if you want to transform the submitted
+    # data before it's persisted. For example, the following would turn all
+    # empty values into nil values. It uses other APIs such as `resource_class`
+    # and `dashboard`:
+    #
+    # def resource_params
+    #   params.require(resource_class.model_name.param_key).
+    #     permit(dashboard.permitted_attributes(action_name)).
+    #     transform_values { |value| value == "" ? nil : value }
+    # end
+
+    # See https://administrate-demo.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/controllers/admin/brands_controller.rb
+++ b/app/controllers/admin/brands_controller.rb
@@ -1,0 +1,46 @@
+module Admin
+  class BrandsController < Admin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   super
+    #   send_foo_updated_email(requested_resource)
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # The result of this lookup will be available as `requested_resource`
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #   if current_user.super_admin?
+    #     resource_class
+    #   else
+    #     resource_class.with_less_stuff
+    #   end
+    # end
+
+    # Override `resource_params` if you want to transform the submitted
+    # data before it's persisted. For example, the following would turn all
+    # empty values into nil values. It uses other APIs such as `resource_class`
+    # and `dashboard`:
+    #
+    # def resource_params
+    #   params.require(resource_class.model_name.param_key).
+    #     permit(dashboard.permitted_attributes(action_name)).
+    #     transform_values { |value| value == "" ? nil : value }
+    # end
+
+    # See https://administrate-demo.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/controllers/admin/likes_controller.rb
+++ b/app/controllers/admin/likes_controller.rb
@@ -1,0 +1,46 @@
+module Admin
+  class LikesController < Admin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   super
+    #   send_foo_updated_email(requested_resource)
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # The result of this lookup will be available as `requested_resource`
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #   if current_user.super_admin?
+    #     resource_class
+    #   else
+    #     resource_class.with_less_stuff
+    #   end
+    # end
+
+    # Override `resource_params` if you want to transform the submitted
+    # data before it's persisted. For example, the following would turn all
+    # empty values into nil values. It uses other APIs such as `resource_class`
+    # and `dashboard`:
+    #
+    # def resource_params
+    #   params.require(resource_class.model_name.param_key).
+    #     permit(dashboard.permitted_attributes(action_name)).
+    #     transform_values { |value| value == "" ? nil : value }
+    # end
+
+    # See https://administrate-demo.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/controllers/admin/products_controller.rb
+++ b/app/controllers/admin/products_controller.rb
@@ -1,0 +1,46 @@
+module Admin
+  class ProductsController < Admin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   super
+    #   send_foo_updated_email(requested_resource)
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # The result of this lookup will be available as `requested_resource`
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #   if current_user.super_admin?
+    #     resource_class
+    #   else
+    #     resource_class.with_less_stuff
+    #   end
+    # end
+
+    # Override `resource_params` if you want to transform the submitted
+    # data before it's persisted. For example, the following would turn all
+    # empty values into nil values. It uses other APIs such as `resource_class`
+    # and `dashboard`:
+    #
+    # def resource_params
+    #   params.require(resource_class.model_name.param_key).
+    #     permit(dashboard.permitted_attributes(action_name)).
+    #     transform_values { |value| value == "" ? nil : value }
+    # end
+
+    # See https://administrate-demo.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/controllers/admin/reviews_controller.rb
+++ b/app/controllers/admin/reviews_controller.rb
@@ -1,0 +1,46 @@
+module Admin
+  class ReviewsController < Admin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   super
+    #   send_foo_updated_email(requested_resource)
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # The result of this lookup will be available as `requested_resource`
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #   if current_user.super_admin?
+    #     resource_class
+    #   else
+    #     resource_class.with_less_stuff
+    #   end
+    # end
+
+    # Override `resource_params` if you want to transform the submitted
+    # data before it's persisted. For example, the following would turn all
+    # empty values into nil values. It uses other APIs such as `resource_class`
+    # and `dashboard`:
+    #
+    # def resource_params
+    #   params.require(resource_class.model_name.param_key).
+    #     permit(dashboard.permitted_attributes(action_name)).
+    #     transform_values { |value| value == "" ? nil : value }
+    # end
+
+    # See https://administrate-demo.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,46 @@
+module Admin
+  class UsersController < Admin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   super
+    #   send_foo_updated_email(requested_resource)
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # The result of this lookup will be available as `requested_resource`
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #   if current_user.super_admin?
+    #     resource_class
+    #   else
+    #     resource_class.with_less_stuff
+    #   end
+    # end
+
+    # Override `resource_params` if you want to transform the submitted
+    # data before it's persisted. For example, the following would turn all
+    # empty values into nil values. It uses other APIs such as `resource_class`
+    # and `dashboard`:
+    #
+    # def resource_params
+    #   params.require(resource_class.model_name.param_key).
+    #     permit(dashboard.permitted_attributes(action_name)).
+    #     transform_values { |value| value == "" ? nil : value }
+    # end
+
+    # See https://administrate-demo.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/dashboards/bookmark_dashboard.rb
+++ b/app/dashboards/bookmark_dashboard.rb
@@ -1,0 +1,66 @@
+require "administrate/base_dashboard"
+
+class BookmarkDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    review: Field::BelongsTo,
+    user: Field::BelongsTo,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+    id
+    review
+    user
+    created_at
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+    id
+    review
+    user
+    created_at
+    updated_at
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    review
+    user
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how bookmarks are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(bookmark)
+  #   "Bookmark ##{bookmark.id}"
+  # end
+end

--- a/app/dashboards/brand_dashboard.rb
+++ b/app/dashboards/brand_dashboard.rb
@@ -1,0 +1,72 @@
+require "administrate/base_dashboard"
+
+class BrandDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    name: Field::String,
+    official_shopping_url: Field::String,
+    official_url: Field::String,
+    products: Field::HasMany,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+    id
+    name
+    official_shopping_url
+    official_url
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+    id
+    name
+    official_shopping_url
+    official_url
+    products
+    created_at
+    updated_at
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    name
+    official_shopping_url
+    official_url
+    products
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how brands are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(brand)
+  #   "#{brand.id}"
+  # end
+end

--- a/app/dashboards/like_dashboard.rb
+++ b/app/dashboards/like_dashboard.rb
@@ -1,0 +1,66 @@
+require "administrate/base_dashboard"
+
+class LikeDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    review: Field::BelongsTo,
+    user: Field::BelongsTo,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+    id
+    review
+    user
+    created_at
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+    id
+    review
+    user
+    created_at
+    updated_at
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    review
+    user
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how likes are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(like)
+  #   "Like ##{like.id}"
+  # end
+end

--- a/app/dashboards/product_dashboard.rb
+++ b/app/dashboards/product_dashboard.rb
@@ -1,0 +1,72 @@
+require "administrate/base_dashboard"
+
+class ProductDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    brand: Field::BelongsTo,
+    category_id: Field::Number,
+    name: Field::String,
+    reviews: Field::HasMany,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+    id
+    brand
+    category_id
+    name
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+    id
+    brand
+    name
+    category_id
+    reviews
+    created_at
+    updated_at
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    brand
+    category_id
+    name
+    reviews
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how products are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(product)
+  #   "#{product.id}"
+  # end
+end

--- a/app/dashboards/review_dashboard.rb
+++ b/app/dashboards/review_dashboard.rb
@@ -11,8 +11,7 @@ class ReviewDashboard < Administrate::BaseDashboard
     id: Field::Number,
     body: Field::String,
     bookmarks: Field::HasMany,
-    images_attachments: Field::HasMany,
-    images_blobs: Field::HasMany,
+    images: Field::ActiveStorage,
     likes: Field::HasMany,
     paper: Field::String,
     pen: Field::String,
@@ -32,7 +31,7 @@ class ReviewDashboard < Administrate::BaseDashboard
     id
     body
     bookmarks
-    images_attachments
+    images
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
@@ -41,8 +40,7 @@ class ReviewDashboard < Administrate::BaseDashboard
     id
     body
     bookmarks
-    images_attachments
-    images_blobs
+    images
     likes
     paper
     pen
@@ -59,8 +57,7 @@ class ReviewDashboard < Administrate::BaseDashboard
   FORM_ATTRIBUTES = %i[
     body
     bookmarks
-    images_attachments
-    images_blobs
+    images
     likes
     paper
     pen
@@ -87,4 +84,7 @@ class ReviewDashboard < Administrate::BaseDashboard
   # def display_resource(review)
   #   "Review ##{review.id}"
   # end
+  def permitted_attributes(_action = nil)
+    super + [:images => []]
+  end
 end

--- a/app/dashboards/review_dashboard.rb
+++ b/app/dashboards/review_dashboard.rb
@@ -1,0 +1,90 @@
+require "administrate/base_dashboard"
+
+class ReviewDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    body: Field::String,
+    bookmarks: Field::HasMany,
+    images_attachments: Field::HasMany,
+    images_blobs: Field::HasMany,
+    likes: Field::HasMany,
+    paper: Field::String,
+    pen: Field::String,
+    product: Field::BelongsTo,
+    title: Field::String,
+    user: Field::BelongsTo,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+    id
+    body
+    bookmarks
+    images_attachments
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+    id
+    body
+    bookmarks
+    images_attachments
+    images_blobs
+    likes
+    paper
+    pen
+    product
+    title
+    user
+    created_at
+    updated_at
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    body
+    bookmarks
+    images_attachments
+    images_blobs
+    likes
+    paper
+    pen
+    product
+    title
+    user
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how reviews are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(review)
+  #   "Review ##{review.id}"
+  # end
+end

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -1,0 +1,111 @@
+require "administrate/base_dashboard"
+
+class UserDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    account: Field::String,
+    avatar_attachment: Field::HasOne,
+    avatar_blob: Field::HasOne,
+    body: Field::String,
+    bookmark_reviews: Field::HasMany,
+    bookmarks: Field::HasMany,
+    email: Field::String,
+    encrypted_password: Field::String,
+    instagram_account: Field::String,
+    likes: Field::HasMany,
+    name: Field::String,
+    remember_created_at: Field::DateTime,
+    reset_password_sent_at: Field::DateTime,
+    reset_password_token: Field::String,
+    reviews: Field::HasMany,
+    x_account: Field::String,
+    youtube_account: Field::String,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+    id
+    account
+    avatar_attachment
+    avatar_blob
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+    id
+    account
+    avatar_attachment
+    avatar_blob
+    body
+    bookmark_reviews
+    bookmarks
+    email
+    encrypted_password
+    instagram_account
+    likes
+    name
+    remember_created_at
+    reset_password_sent_at
+    reset_password_token
+    reviews
+    x_account
+    youtube_account
+    created_at
+    updated_at
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    account
+    avatar_attachment
+    avatar_blob
+    body
+    bookmark_reviews
+    bookmarks
+    email
+    encrypted_password
+    instagram_account
+    likes
+    name
+    remember_created_at
+    reset_password_sent_at
+    reset_password_token
+    reviews
+    x_account
+    youtube_account
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how users are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(user)
+  #   "User ##{user.id}"
+  # end
+end

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -10,8 +10,7 @@ class UserDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     id: Field::Number,
     account: Field::String,
-    avatar_attachment: Field::HasOne,
-    avatar_blob: Field::HasOne,
+    avatar: Field::ActiveStorage,
     body: Field::String,
     bookmark_reviews: Field::HasMany,
     bookmarks: Field::HasMany,
@@ -38,8 +37,7 @@ class UserDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = %i[
     id
     account
-    avatar_attachment
-    avatar_blob
+    avatar
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
@@ -47,8 +45,7 @@ class UserDashboard < Administrate::BaseDashboard
   SHOW_PAGE_ATTRIBUTES = %i[
     id
     account
-    avatar_attachment
-    avatar_blob
+    avatar
     body
     bookmark_reviews
     bookmarks
@@ -72,8 +69,7 @@ class UserDashboard < Administrate::BaseDashboard
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
     account
-    avatar_attachment
-    avatar_blob
+    avatar
     body
     bookmark_reviews
     bookmarks

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,9 +1,12 @@
 <nav class="grid-flow-col gap-4">
-  <%= link_to 'お問い合わせ', contact_path %>
+  <%= link_to "お問い合わせ", contact_path %>
   <!-- ページ作成後使用
   <%= link_to '利用規約', '#' %>
   <%= link_to 'プライバシーポリシー', '#' %>
   -->
+  <% if current_user&.admin? %>
+    <%= link_to "管理", admin_root_path %>
+  <% end %>
 </nav>
 
 <aside class="grid-flow-col items-center justify-self-end">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,17 @@ Rails.application.routes.draw do
     get :search, on: :collection
   end
   resources :bookmarks, only: %i[create destroy]
+
+  namespace :admin do
+    resources :bookmarks
+    resources :brands
+    resources :likes
+    resources :products
+    resources :reviews
+    resources :users
+
+    root to: "reviews#index"
+  end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20250425070142_add_admin_to_users.rb
+++ b/db/migrate/20250425070142_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_17_054736) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_25_070142) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -109,6 +109,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_17_054736) do
     t.string "x_account"
     t.string "instagram_account"
     t.string "youtube_account"
+    t.boolean "admin", default: false
     t.index ["account"], name: "index_users_on_account", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["name"], name: "index_users_on_name", unique: true


### PR DESCRIPTION
# 実施タスク
closes #135 
gem Administrateを導入し、管理画面を作成
管理者ユーザーを作成して管理者のみ管理画面にアクセスできるようにする。

# 実施内容
- Gemfileに`gem "administrate"`と`gem "administrate-field-active_storage"`を追加しました。
- `docker compose exec web rails generate administrate:install`を実行して管理画面を作成しました。
- config/routes.rbで自動生成されたルーティングを微修正しました。（ルートページがブックマークになってたのでレビューに変更）
- userモデルにadminカラムを追加。管理者ユーザーを設定しました。
- フッターに管理者ユーザーにのみ管理者ページへのリンクが表示されるようにしました。

# 備考
- `gem "administrate-field-active_storage"`を追加してダッシュボードのavatarとimagesの記述をadministrate-field-active_storageの記述に変更しないとエラーになるので変更しています。
- ActiveHashで実装しているCategoryのテーブルを探してエラーになっていたので、暫定的にapp/dashboards/product_dashboard.rbの`category: Field::BelongsTo`→`category_id: Field::Number`に変更しています。Categoryにのidと同じ数字を入れることができればいいので、セレクトボックス等で対応することになるとおもいます。