### PR TITLE
fix: デプロイ時のエラー対応

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,6 +25,7 @@ Rails.application.configure do
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
+  config.assets.css_compressor = nil
 
   # Do not fall back to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false


### PR DESCRIPTION
# 実施タスク
デプロイ時のエラーを修正

# 実施内容
### 出てるエラー
```
#19 6.448 W, [2025-04-25T08:19:37.510353 #7]  WARN -- : Removed sourceMappingURL comment for missing asset '/assets/application.js.map' from /rails/app/assets/builds/application.js
#19 6.885 bin/rails aborted!
#19 6.885 SassC::SyntaxError: Error: Function rgb is missing argument $green. (SassC::SyntaxError)
#19 6.885         on line 2640 of stdin
#19 6.885 >>   border-color: rgb(0 0 0 / var(--tw-border-opacity, 1));
#19 6.885 
#19 6.885    ----------------^
#19 6.885 
#19 6.885 Tasks: TOP => assets:precompile
#19 6.885 (See full trace by running task with --trace)
#19 ERROR: process "/bin/sh -c SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile" did not complete successfully: exit code: 1
------
 > [build  9/10] RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile:
6.448 W, [2025-04-25T08:19:37.510353 #7]  WARN -- : Removed sourceMappingURL comment for missing asset '/assets/application.js.map' from /rails/app/assets/builds/application.js
6.885 bin/rails aborted!
6.885 SassC::SyntaxError: Error: Function rgb is missing argument $green. (SassC::SyntaxError)
6.885         on line 2640 of stdin
6.885 >>   border-color: rgb(0 0 0 / var(--tw-border-opacity, 1));
6.885 
6.885    ----------------^
6.885 
6.885 Tasks: TOP => assets:precompile
6.885 (See full trace by running task with --trace)
------
Error: failed to fetch an image or build from source: error building: failed to solve: process "/bin/sh -c SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile" did not complete successfully: exit code: 1
Error: Process completed with exit code 1.
```
### 対応
[administrate-field-active_storageのissue](https://github.com/Dreamersoul/administrate-field-active_storage/issues/103)　の[このコメント](https://github.com/Dreamersoul/administrate-field-active_storage/issues/103#issuecomment-1718652943)が近い事例のようなので、config/environments/production.rbに`config.assets.css_compressor = nil`を追加してみた。
他、参考：
[【Rails】 SassC::SyntaxError について](https://qiita.com/takakou/items/b1cc3dca18966ed2b9f4)
→`SassC::SyntaxError`が出ているし、TailwindCSSを使っていて、Scssを使っていないので、設定して問題なさそう？と判断しました。
