### PR TITLE
userの管理画面を編集

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -12,9 +12,9 @@ module Admin
     # This will be used to set the resource for the `show`, `edit`, and `update`
     # actions.
     #
-    # def find_resource(param)
-    #   Foo.find_by!(slug: param)
-    # end
+    def find_resource(param)
+      User.find_by!(account: param)
+    end
 
     # The result of this lookup will be available as `requested_resource`
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -3,10 +3,14 @@ module Admin
     # Overwrite any of the RESTful controller actions to implement custom behavior
     # For example, you may want to send an email after a foo is updated.
     #
-    # def update
-    #   super
-    #   send_foo_updated_email(requested_resource)
-    # end
+    def update
+      super
+      if params[:user][:avatar].present?
+        process_avatar = ImageProcessing::MiniMagick.source(params[:user][:avatar].tempfile).resize_to_fit(300, 300).convert("webp").call
+        filename_base = File.basename(params[:user][:avatar].original_filename, ".*")
+        requested_resource.avatar.attach(io: process_avatar, filename: "#{filename_base}.webp", content_type: "image/webp")
+      end
+    end
 
     # Override this method to specify custom lookup behavior.
     # This will be used to set the resource for the `show`, `edit`, and `update`

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -25,6 +25,15 @@ module Admin
       resource_class.with_attached_avatar
     end
 
+    # For illustrative purposes only.
+    #
+    # **SECURITY NOTICE**: first verify whether current user is authorized to perform the action.
+    def destroy_avatar
+      avatar = requested_resource.avatar
+      avatar.purge
+      redirect_back(fallback_location: requested_resource)
+    end
+
     # Override `resource_params` if you want to transform the submitted
     # data before it's persisted. For example, the following would turn all
     # empty values into nil values. It uses other APIs such as `resource_class`

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -21,13 +21,9 @@ module Admin
     # Override this if you have certain roles that require a subset
     # this will be used to set the records shown on the `index` action.
     #
-    # def scoped_resource
-    #   if current_user.super_admin?
-    #     resource_class
-    #   else
-    #     resource_class.with_less_stuff
-    #   end
-    # end
+    def scoped_resource
+      resource_class.with_attached_avatar
+    end
 
     # Override `resource_params` if you want to transform the submitted
     # data before it's persisted. For example, the following would turn all

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -25,6 +25,7 @@ class UserDashboard < Administrate::BaseDashboard
     reviews: Field::HasMany,
     x_account: Field::String,
     youtube_account: Field::String,
+    admin: Field::Boolean,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -37,7 +38,9 @@ class UserDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = %i[
     id
     account
+    name
     avatar
+    admin
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
@@ -45,21 +48,21 @@ class UserDashboard < Administrate::BaseDashboard
   SHOW_PAGE_ATTRIBUTES = %i[
     id
     account
+    name
+    email
+    admin
     avatar
     body
+    instagram_account
+    x_account
+    youtube_account
+    likes
     bookmark_reviews
     bookmarks
-    email
-    encrypted_password
-    instagram_account
-    likes
-    name
     remember_created_at
     reset_password_sent_at
     reset_password_token
     reviews
-    x_account
-    youtube_account
     created_at
     updated_at
   ].freeze
@@ -69,21 +72,18 @@ class UserDashboard < Administrate::BaseDashboard
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
     account
+    name
+    email
+    admin
     avatar
     body
-    bookmark_reviews
-    bookmarks
-    email
-    encrypted_password
     instagram_account
-    likes
-    name
-    remember_created_at
-    reset_password_sent_at
-    reset_password_token
-    reviews
     x_account
     youtube_account
+    reviews
+    likes
+    bookmark_reviews
+    bookmarks
   ].freeze
 
   # COLLECTION_FILTERS
@@ -101,7 +101,7 @@ class UserDashboard < Administrate::BaseDashboard
   # Overwrite this method to customize how users are displayed
   # across all pages of the admin dashboard.
   #
-  # def display_resource(user)
-  #   "User ##{user.id}"
-  # end
+  def display_resource(user)
+    "#{user.name}"
+  end
 end

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -10,7 +10,11 @@ class UserDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     id: Field::Number,
     account: Field::String,
-    avatar: Field::ActiveStorage,
+    avatar: Field::ActiveStorage.with_options(
+      destroy_url: proc do |namespace, resource, attachment|
+        [:avatar_admin_user, { id: resource.id, attachment_id: attachment.id }]
+      end
+    ),
     body: Field::String,
     bookmark_reviews: Field::HasMany,
     bookmarks: Field::HasMany,

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -12,7 +12,7 @@ class UserDashboard < Administrate::BaseDashboard
     account: Field::String,
     avatar: Field::ActiveStorage.with_options(
       destroy_url: proc do |namespace, resource, attachment|
-        [:avatar_admin_user, { id: resource.id, attachment_id: attachment.id }]
+        [:avatar_admin_user, { id: resource.account, attachment_id: attachment.id }]
       end
     ),
     body: Field::String,

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -1,0 +1,76 @@
+<%#
+# Form Partial
+
+This partial is rendered on a resource's `new` and `edit` pages,
+and renders all form fields for a resource's editable attributes.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Form][1].
+  Contains helper methods to display a form,
+  and knows which attributes should be displayed in the resource's form.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
+%>
+
+<%= form_for([namespace, page.resource], html: { class: "form" }) do |f| %>
+  <% if page.resource.errors.any? %>
+    <div id="error_explanation">
+      <h2>
+        <%= t(
+          "administrate.form.errors",
+          pluralized_errors: pluralize(page.resource.errors.count, t("administrate.form.error")),
+          resource_name: display_resource_name(page.resource_name, singular: true)
+        ) %>
+      </h2>
+
+      <ul>
+        <% page.resource.errors.full_messages.each do |message| %>
+          <li class="flash-error"><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <% page.attributes(controller.action_name).each do |title, attributes| -%>
+    <fieldset class="<%= "field-unit--nested" if title.present? %>">
+      <% if title.present? %>
+        <legend><%= t "helpers.label.#{f.object_name}.#{title}", default: title %></legend>
+      <% end %>
+
+      <% attributes.each do |attribute| %>
+        <div class="field-unit field-unit--<%= attribute.html_class %> field-unit--<%= requireness(attribute) %>">
+          <%= render_field attribute, f: f %>
+
+          <% hint_key = "administrate.field_hints.#{page.resource_name}.#{attribute.name}" %>
+          <% if I18n.exists?(hint_key) -%>
+            <div class="field-unit__hint">
+              <%= I18n.t(hint_key) %>
+            </div>
+          <% end -%>
+        </div>
+      <% end %>
+    </fieldset>
+  <% end -%>
+  <div class="field-unit field-unit--string">
+    <div class="field-unit__label">
+      <label for="admin_user_password">パスワード</label>
+    </div>
+    <div class="field-unit__field">
+      <%= f.password_field :password %>
+    </div>
+  </div>
+  <div class="field-unit field-unit--string">
+    <div class="field-unit__label">
+      <label for="admin_user_password_confirmation">パスワード(確認用)</label>
+    </div>
+    <div class="field-unit__field">
+      <%= f.password_field :password_confirmation %>
+    </div>
+  </div>
+
+  <div class="form-actions">
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -1,0 +1,37 @@
+<%#
+# New
+
+This view is the template for the "new resource" page.
+It displays a header, and then renders the `_form` partial
+to do the heavy lifting.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Form][1].
+  Contains helper methods to help display a form,
+  and knows which attributes should be displayed in the resource's form.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
+%>
+
+<% content_for(:title) do %>
+  <%= t(
+    "administrate.actions.new_resource",
+    name: display_resource_name(page.resource_name).titleize
+  ) %>
+<% end %>
+
+<header class="main-content__header">
+  <h1 class="main-content__page-title">
+    <%= content_for(:title) %>
+  </h1>
+
+  <div>
+    <%= link_to t("administrate.actions.back"), :back, class: "button" %>
+  </div>
+</header>
+
+<section class="main-content__body">
+  <%= render "form", page: page %>
+</section>

--- a/app/views/fields/active_storage/_item.html.erb
+++ b/app/views/fields/active_storage/_item.html.erb
@@ -1,0 +1,48 @@
+<%#
+# Item Partial
+
+This partial renders attached items.
+
+Attachments of type image, video and audio are emedded.  For all other types
+we try use it's preview.  If all else fails we simply link to the attached file.
+
+This partial will optionally show a `remove` link next to each attachment which is
+controlled via a boolean local variable.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::Image].
+  A wrapper around the image url pulled from the database.
+- `attachment`:
+  Reference to the file
+- `size`:
+  [x, y]
+  Maximum size of the ActiveStorage preview.
+- `preview_only`:
+  If true, show only the previous and not the name or destroy link
+%>
+<% preview_only = local_assigns.fetch(:preview_only, false)
+   display_preview = local_assigns.fetch(:display_preview, field.show_display_preview?) %>
+<% if display_preview && attachment.persisted? %>
+  <div>
+    <%= render partial: 'fields/active_storage/preview', locals: local_assigns %>
+  </div>
+<% end %>
+
+<% unless preview_only %>
+<% if attachment.persisted? %>
+  <div>
+    <%= link_to attachment.filename, field.blob_url(attachment), title: attachment.filename %>
+  </div>
+<% end %>
+
+<% if action_name.in?(%w(show edit)) && field.destroy_url.present? %>
+  <% destroy_url = field.destroy_url.call(namespace, field.data.record, attachment) %>
+  <div>
+    <%= link_to I18n.t("administrate.fields.active_storage.remove", default: 'Remove'),
+                destroy_url, method: :delete, class: 'remove-attachment-link', data: { confirm: t("administrate.actions.confirm") } %>
+  </div>
+  <hr>
+<% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,9 @@ Rails.application.routes.draw do
     resources :likes
     resources :products
     resources :reviews
-    resources :users
+    resources :users do
+      delete :avatar, on: :member, action: :destroy_avatar
+    end
 
     root to: "reviews#index"
   end


### PR DESCRIPTION
# 実施タスク
close #136 
管理画面でユーザー登録、編集ができるように実装

# 実施内容
- app/dashboards/user_dashboard.rbに`admin`カラムと`gem administrate-field-active_storage`の記述を追加して、表示するカラムや表示順を調整。
- ドキュメントに従いapp/controllers/admin/users_controller.rbの`find_resource`メソッドをオーバーライド。
- app/controllers/admin/users_controller.rbのupdateとcreateアクションをオーバーライドしてユーザーの登録編集を管理画面でできるように設定。画像変換メソッドも定義。
- app/views/fields/active_storage/_item.html.erbをオーバーライドしてindex画面にremoveボタンが表示されないように設定。
- app/views/admin/users/_form.html.erbをオーバーライドして`password`と`password_confirmation`入力フォームを追加

# 備考
- createのオーバーライドはsuper使うと`resource`が見つからないエラーが出ます。
- 画像変換用の`process_and_resize_avatar`メソッド作りました。
- `gem administrate-field-active_storage`の公式ドキュメントにあったN+1問題解消用のコードをapp/controllers/admin/users_controller.rbに記述しています。