### PR TITLE
reviewの管理画面を編集

### DIFF
--- a/app/controllers/admin/reviews_controller.rb
+++ b/app/controllers/admin/reviews_controller.rb
@@ -33,6 +33,16 @@ module Admin
       end
     end
 
+    def destroy
+      if requested_resource.destroy
+        requested_resource.images.purge_later if requested_resource.images.attached?
+        flash[:notice] = translate_with_resource("destroy.success")
+      else
+        flash[:error] = requested_resource.errors.full_messages.join("<br/>")
+      end
+      redirect_to after_resource_destroyed_path(requested_resource), status: :see_other
+    end
+
     # Override this method to specify custom lookup behavior.
     # This will be used to set the resource for the `show`, `edit`, and `update`
     # actions.

--- a/app/controllers/admin/reviews_controller.rb
+++ b/app/controllers/admin/reviews_controller.rb
@@ -76,6 +76,14 @@ module Admin
 
     private
 
+    def default_sorting_attribute
+      :id
+    end
+
+    def default_sorting_direction
+      :desc
+    end
+
     def process_images(params)
       if params[:images].present?
         params[:images].each do |image|

--- a/app/dashboards/review_dashboard.rb
+++ b/app/dashboards/review_dashboard.rb
@@ -11,7 +11,14 @@ class ReviewDashboard < Administrate::BaseDashboard
     id: Field::Number,
     body: Field::String,
     bookmarks: Field::HasMany,
-    images: Field::ActiveStorage,
+    images: Field::ActiveStorage.with_options(
+      index_preview_size: [80, 80],
+      show_preview_size: [350, 350],
+      file_field_options: { include_hidden: false },
+      destroy_url: proc do |namespace, resource, attachment|
+        [:images_admin_review, { attachment_id: attachment.id }]
+      end
+    ),
     likes: Field::HasMany,
     paper: Field::String,
     pen: Field::String,
@@ -30,23 +37,23 @@ class ReviewDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = %i[
     id
     body
-    bookmarks
     images
+    product
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
     id
+    user
+    title
     body
-    bookmarks
-    images
-    likes
+    product
     paper
     pen
-    product
-    title
-    user
+    images
+    likes
+    bookmarks
     created_at
     updated_at
   ].freeze
@@ -55,15 +62,13 @@ class ReviewDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
+    title
     body
-    bookmarks
+    user
+    product
     images
-    likes
     paper
     pen
-    product
-    title
-    user
   ].freeze
 
   # COLLECTION_FILTERS

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,9 @@ Rails.application.routes.draw do
     resources :brands
     resources :likes
     resources :products
-    resources :reviews
+    resources :reviews do
+      delete :images, on: :member, action: :destroy_image
+    end
     resources :users do
       delete :avatar, on: :member, action: :destroy_avatar
     end


### PR DESCRIPTION
# 実施タスク
closes #137 
管理画面からレビューの投稿、編集ができるように実装

# 実施内容
- config/routes.rbに画像削除用のルーティングを追加しました。
- app/controllers/admin/reviews_controller.rbに画像削除用の`destroy_image`アクションを追加しました。
- 画像加工用のメソッドを定義し、`create`と`update`をオーバーライドしました。また、`destroy`アクションをオーバーライドして`destroy`成功時に添付画像を`purge`するようにしてます。
- app/dashboards/review_dashboard.rbに表示画像のリサイズと`file_field`に`includes_hidden: false`を追加する設定、画像削除用の設定を追加してます。

# 備考
- どうも`has_many_attached`関連付けだと、未保存の親モデルに`images`を`attach`できないようなので、画像の加工処理はparamsを直接加工する処理で行います。`save`後に加工後の画像を`attach`してみましたが、上書きにならずに`未加工の画像と加工済みの画像の両方が保存`されました。`has_many_attached`関連付けの時に`attach`を明示的に使用すると、上書き保存ではなく画像を追加する挙動になるようです。→[参考](https://github.com/rails/rails/blob/v7.0.2.3/activestorage/lib/active_storage/attached/model.rb#L150)
よって、`build`の引数に`process_images(params)`を渡して、加工したパラメータを`build`することにしました。
- indexのデフォルトの並び替えをID降順に変更してます。これで開くたびに並び順がぐちゃぐちゃになることがなくなります。