### PR TITLE
productの管理画面を編集

### DIFF
--- a/app/dashboards/brand_dashboard.rb
+++ b/app/dashboards/brand_dashboard.rb
@@ -66,7 +66,7 @@ class BrandDashboard < Administrate::BaseDashboard
   # Overwrite this method to customize how brands are displayed
   # across all pages of the admin dashboard.
   #
-  # def display_resource(brand)
-  #   "#{brand.id}"
-  # end
+  def display_resource(brand)
+    "#{brand.name}"
+  end
 end

--- a/app/dashboards/product_dashboard.rb
+++ b/app/dashboards/product_dashboard.rb
@@ -12,7 +12,7 @@ class ProductDashboard < Administrate::BaseDashboard
     name: Field::String,
     brand: Field::BelongsTo,
     category_id: Field::Select.with_options(
-      collection: Category.all.collect { |c| [ "#{c.color}", c.id ] },
+      collection: Category.all.collect { |c| [ c.color, c.id ] },
       include_blank: true,
     ),
     reviews: Field::HasMany,

--- a/app/dashboards/product_dashboard.rb
+++ b/app/dashboards/product_dashboard.rb
@@ -9,9 +9,15 @@ class ProductDashboard < Administrate::BaseDashboard
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
     id: Field::Number,
-    brand: Field::BelongsTo,
-    category_id: Field::Number,
     name: Field::String,
+    brand: Field::BelongsTo,
+    category_id: Field::Select.with_options(
+      collection: Category.all.collect { |c| [ "#{c.color}", c.id ] },
+      include_blank: true,
+      getter: -> (field) {
+        field.resource.color
+      }
+    ),
     reviews: Field::HasMany,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
@@ -24,17 +30,17 @@ class ProductDashboard < Administrate::BaseDashboard
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
     id
+    name
     brand
     category_id
-    name
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
     id
-    brand
     name
+    brand
     category_id
     reviews
     created_at
@@ -45,9 +51,9 @@ class ProductDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
+    name
     brand
     category_id
-    name
     reviews
   ].freeze
 
@@ -66,7 +72,7 @@ class ProductDashboard < Administrate::BaseDashboard
   # Overwrite this method to customize how products are displayed
   # across all pages of the admin dashboard.
   #
-  # def display_resource(product)
-  #   "#{product.id}"
-  # end
+  def display_resource(product)
+    "#{product.name}"
+  end
 end

--- a/app/dashboards/product_dashboard.rb
+++ b/app/dashboards/product_dashboard.rb
@@ -14,9 +14,6 @@ class ProductDashboard < Administrate::BaseDashboard
     category_id: Field::Select.with_options(
       collection: Category.all.collect { |c| [ "#{c.color}", c.id ] },
       include_blank: true,
-      getter: -> (field) {
-        field.resource.color
-      }
     ),
     reviews: Field::HasMany,
     created_at: Field::DateTime,

--- a/app/views/fields/select/_index.html.erb
+++ b/app/views/fields/select/_index.html.erb
@@ -1,0 +1,16 @@
+<%#
+# Select Index Partial
+
+This partial renders a selectable text attribute,
+to be displayed on a resource's index page.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::Select][1].
+  A wrapper around the attribute pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Select
+%>
+
+<%= Category.find(field.data).color %>

--- a/app/views/fields/select/_show.html.erb
+++ b/app/views/fields/select/_show.html.erb
@@ -1,0 +1,16 @@
+<%#
+# Select Index Partial
+
+This partial renders a selectable text attribute,
+to be displayed on a resource's index page.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::Select][1].
+  A wrapper around the attribute pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Select
+%>
+
+<%= Category.find(field.data).color %>


### PR DESCRIPTION
# 実施タスク
closes #138
管理画面からインクの登録・編集ができるように実装

# 実施内容
- app/dashboards/product_dashboard.rbを編集して、Categoryをセレクトボックスで選択できるようにしました。`collection`に`[label, value]`の形式で渡せば良いようです → [参考](https://github.com/thoughtbot/administrate/pull/1646)
- デフォルトのままだと`Product #id`や`Brand #id`といった形で表示されてしまい、どれがどのインク、ブランドかわかりにくいので、`display_resource`メソッドを編集してそれぞれインク名、ブランド名で表示されるように変更しました。
- セレクトボックスのデフォルトの表示はデータベースに保存されている値(`value`)になるようなので、ビュー（app/views/fields/select/_index.html.erb、app/views/fields/select/_show.html.erb）をオーバーライドして`color`が表示されるようにしました。

# 備考
今はまだ入力フォームでのBrandの選択はセレクトボックスでも問題ない数ですが、今後セレクトボックスで支障が出てくるようならテキストフィールドでの入力形式に変更しようと思います。