### PR TITLE
レスポンシブ対応

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -20,3 +20,13 @@
     @apply border-transparent hover:text-gray-600 hover:border-gray-300 dark:hover:text-gray-300
   }
 }
+
+dialog.slideover[open] {
+  animation: slide-in-from-left 250ms forwards ease;
+}
+
+@keyframes slide-in-from-left{
+  from {
+    transform: translateX(-100%);
+  }
+}

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -25,8 +25,18 @@ dialog.slideover[open] {
   animation: slide-in-from-left 250ms forwards ease;
 }
 
+dialog.slideover-search[open] {
+  animation: slide-in-from-top 250ms forwards ease;
+}
+
 @keyframes slide-in-from-left{
   from {
     transform: translateX(-100%);
+  }
+}
+
+@keyframes slide-in-from-top{
+  from {
+    transform: translateY(-100%);
   }
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
-  allow_browser versions: :modern
+  # allow_browser versions: :modern
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   protected

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -7,3 +7,6 @@ application.debug = false
 window.Stimulus   = application
 
 export { application }
+
+import { Slideover } from "tailwindcss-stimulus-components"
+application.register('slideover', Slideover)

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,5 +1,5 @@
-<div class="container mx-auto w-[540px] px-10 py-5">
-  <h1 class="text-5xl font-bold text-center mb-10"><%= t('users.edit.title') %></h1>
+<div class="container mx-auto w-full sm:w-[540px] px-10 py-5">
+  <h1 class="text-[24px] sm:text-5xl font-bold text-center mb-10"><%= t('users.edit.title') %></h1>
 
   <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
     <%= render "devise/shared/error_messages", resource: resource %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,6 +1,6 @@
 
-<div class="container mx-auto w-[540px] px-10 py-5">
-  <h1 class="text-5xl font-bold text-center mb-10"><%= t('devise.registrations.new.title') %></h1>
+<div class="container mx-auto w-full sm:w-[540px] px-10 py-5">
+  <h1 class="text-[24px] sm:text-5xl font-bold text-center mb-10"><%= t('devise.registrations.new.title') %></h1>
 
   <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
     <%= render "devise/shared/error_messages", resource: resource %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,5 +1,5 @@
-<div class="container mx-auto w-[540px] px-10 py-5">
-  <h1 class="text-5xl font-bold text-center mb-10"><%= t('devise.sessions.new.title') %></h1>
+<div class="container mx-auto w-full sm:w-[540px] px-10 py-5">
+  <h1 class="text-[24px] sm:text-5xl font-bold text-center mb-10"><%= t('devise.sessions.new.title') %></h1>
 
   <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
     <div class="field">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,47 +1,49 @@
-<div class="navbar bg-base-100 border-b border-primary h-[70px]">
-  <div class="navbar-start">
-    <%= link_to '/', class: "text-lg" do %>
-      <%= image_tag 'header_logo.png', class: 'h-[50px] w-[200px] object-cover' %>
-    <% end %>
-  </div>
-  <div class="navbar-center">
-    <%= render 'shared/search_form', url: search_reviews_path %>
-  </div>
-  <div class="navbar-end">
-    <% if user_signed_in? %>
-      <ul class="menu menu-horizontal px-1 flex justify-center items-center gap-1 mx-4">
-        <li>
-          <%= link_to new_review_path, class: "btn btn-secondary" do %>
-            <i class="fa-solid fa-pen-to-square"></i>
-            <span><%= t('header.post') %></span>
-          <% end %>
-        </li>
-        <details class="dropdown dropdown-end ">
-          <summary class="inline-flex items-center justify-center gap-2 m-5 cursor-pointer">
-            <div class="avatar">
-              <div class="w-12 rounded-full border-[2px] border-gray-200">
-                <% if current_user.avatar.attached? %>
-                  <%= image_tag current_user.avatar %>
-                <% else %>
-                  <%= image_tag 'kkrn_icon_user_1.png' %>
-                <% end %>
+<div class="hidden sm:block">
+  <div class="navbar bg-base-100 border-b border-primary h-[70px]">
+    <div class="navbar-start">
+      <%= link_to '/', class: "text-lg" do %>
+        <%= image_tag 'header_logo.png', class: 'h-[50px] w-[200px] object-cover' %>
+      <% end %>
+    </div>
+    <div class="navbar-center">
+      <%= render 'shared/search_form', url: search_reviews_path %>
+    </div>
+    <div class="navbar-end">
+      <% if user_signed_in? %>
+        <ul class="menu menu-horizontal px-1 flex justify-center items-center gap-1 mx-4">
+          <li>
+            <%= link_to new_review_path, class: "btn btn-secondary" do %>
+              <i class="fa-solid fa-pen-to-square"></i>
+              <span><%= t('header.post') %></span>
+            <% end %>
+          </li>
+          <details class="dropdown dropdown-end ">
+            <summary class="inline-flex items-center justify-center gap-2 m-5 cursor-pointer">
+              <div class="avatar">
+                <div class="w-12 rounded-full border-[2px] border-gray-200">
+                  <% if current_user.avatar.attached? %>
+                    <%= image_tag current_user.avatar %>
+                  <% else %>
+                    <%= image_tag 'kkrn_icon_user_1.png' %>
+                  <% end %>
+                </div>
               </div>
-            </div>
-            <%= current_user.name %>
-          </summary>
-          <ul class="menu dropdown-content bg-base-100 rounded-box z-[1] w-52 p-2 shadow">
-            <li><%= link_to t('header.mypage'), user_path(current_user) %></li>
-            <li><%= link_to t('header.notification'), "#" %></li>
-            <li><%= link_to t('header.sign_out'), destroy_user_session_path, data: { turbo_method: :delete } %></li>
-          </ul>
-        </details>
-      </ul>
-    <% else %>
-      <ul class="menu menu-horizontal px-1 flex justify-center gap-1 mx-4">
-        <li><%= link_to t('header.sign_in'), user_session_path %></li>
-        <span class="w-[1px] bg-black mx-2"></span>
-        <li><%= link_to t('header.to_register_page'), new_user_registration_path %></li>
-      </ul>
-    <% end %>
+              <%= current_user.name %>
+            </summary>
+            <ul class="menu dropdown-content bg-base-100 rounded-box z-[1] w-52 p-2 shadow">
+              <li><%= link_to t('header.mypage'), user_path(current_user) %></li>
+              <li><%= link_to t('header.notification'), "#" %></li>
+              <li><%= link_to t('header.sign_out'), destroy_user_session_path, data: { turbo_method: :delete } %></li>
+            </ul>
+          </details>
+        </ul>
+      <% else %>
+        <ul class="menu menu-horizontal px-1 flex justify-center gap-1 mx-4">
+          <li><%= link_to t('header.sign_in'), user_session_path %></li>
+          <span class="w-[1px] bg-black mx-2"></span>
+          <li><%= link_to t('header.to_register_page'), new_user_registration_path %></li>
+        </ul>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/layouts/_mobile_header.html.erb
+++ b/app/views/layouts/_mobile_header.html.erb
@@ -1,0 +1,95 @@
+<div class="block sm:hidden">
+  <div class="navbar bg-base-100 border-b border-primary h-[70px]">
+    <div class="navbar-start">
+      <div data-controller="slideover">
+        <dialog data-slideover-target="dialog" data-action="click->slideover#backdropClose" class="slideover h-full max-h-full m-0 w-[344px] p-4 backdrop:bg-black/30">
+          <div class="flex justify-end items-center">
+            <button autofocus data-action="slideover#close" class="btn btn-ghost btn-circle text-sm">✕</button>
+          </div>
+          <div class="flex flex-col justify-center items-center gap-4 border-b border-black pb-4">
+            <% if user_signed_in? %>
+              <div class="flex justify-center items-center gap-2">
+                <div class="avatar">
+                  <div class="w-12 rounded-full border-[2px] border-gray-200">
+                    <% if current_user.avatar.attached? %>
+                      <%= image_tag current_user.avatar %>
+                    <% else %>
+                      <%= image_tag 'kkrn_icon_user_1.png' %>
+                    <% end %>
+                  </div>
+                </div>
+                <%= current_user.name %>
+              </div>
+                <%= link_to new_review_path, class: "btn btn-wide btn-secondary", data: { action: "slideover#close" } do %>
+                  <i class="fa-solid fa-pen-to-square"></i>
+                  <span><%= t('header.post') %></span>
+                <% end %>
+                <%= link_to t('header.mypage'), user_path(current_user), data: { action: "slideover#close" } %>
+                <%= link_to t('header.notification'), "#", data: { action: "slideover#close" } %>
+                <%= link_to t('header.sign_out'), destroy_user_session_path, data: { turbo_method: :delete, action: "slideover#close" } %>
+            <% else %>
+                <%= link_to t('header.sign_in'), user_session_path, class: "btn btn-wide btn-primary", data: { action: "slideover#close" } %>
+                <%= link_to t('header.to_register_page'), new_user_registration_path, class: "btn btn-wide btn-secondary", data: { action: "slideover#close" } %>
+            <% end %>
+          </div>
+          <div class="flex flex-col justify-center items-center mt-10 gap-2">
+            <%= link_to "お問い合わせ", contact_path, data: { action: "slideover#close" } %>
+            <!-- ページ作成後使用
+            <%= link_to '利用規約', '#' %>
+            <%= link_to 'プライバシーポリシー', '#' %>
+            -->
+            <% if current_user&.admin? %>
+              <%= link_to "管理", admin_root_path, data: { action: "slideover#close" } %>
+            <% end %>
+            <p>© 2025 iroGraphica.</p>
+          </div>
+        </dialog>
+        <button data-action="slideover#open" class="btn btn-ghost btn-circle drawer-button">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-5 w-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor">
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M4 6h16M4 12h16M4 18h7" />
+          </svg>
+        </button>
+      </div>
+    </div>
+    <div class="navbar-center">
+      <%= link_to '/', class: "text-lg" do %>
+        <%= image_tag 'header_logo.png', class: 'h-[50px] w-[200px] object-cover' %>
+      <% end %>
+    </div>
+    <div class="navbar-end">
+      <div data-controller="slideover">
+        <dialog data-slideover-target="dialog" class="slideover-search w-full max-w-full m-0 h-[140px] p-4 backdrop:bg-black/30">
+          <div class="mt-6">
+            <%= render 'shared/search_form', url: search_reviews_path %>
+          </div>
+          <div class="flex justify-end mt-2">
+            <button autofocus data-action="slideover#close" class="btn btn-ghost btn-circle text-sm">✕</button>
+          </div>
+        </dialog>
+        <button data-action="slideover#open" class="btn btn-ghost btn-circle">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-5 w-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor">
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/_mobile_header.html.erb
+++ b/app/views/layouts/_mobile_header.html.erb
@@ -67,7 +67,7 @@
     </div>
     <div class="navbar-end">
       <div data-controller="slideover">
-        <dialog data-slideover-target="dialog" class="slideover-search w-full max-w-full m-0 h-[140px] p-4 backdrop:bg-black/30">
+        <dialog data-slideover-target="dialog"  data-action="click->slideover#backdropClose" class="slideover-search w-full max-w-full m-0 h-[140px] p-4 backdrop:bg-black/30">
           <div class="mt-6">
             <%= render 'shared/search_form', url: search_reviews_path %>
           </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,6 +24,7 @@
   <body class="body-font">
     <div class="flex flex-col h-screen">
       <header class="sticky top-0 z-40">
+        <%= render 'layouts/mobile_header' %>
         <%= render 'layouts/header' %>
       </header>
       <main class="flex-grow text-[#333333]">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
   <head>
     <title><%= content_for(:title) || "iroGraphica" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
@@ -30,7 +30,7 @@
         <%= render 'shared/flash_message' %>
         <%= yield %>
       </main>
-      <footer class="footer bg-[#A6ABBD] text-[#424656] items-center p-4 sticky bottom-0 z-40">
+      <footer class="footer bg-[#A6ABBD] text-[#424656] items-center p-4 sticky bottom-0 z-40 hidden sm:block">
         <%= render 'layouts/footer' %>
       </footer>
     </div>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -1,5 +1,5 @@
 <%= render "shared/remote_modal", title: t('product.index.title') do %>
-  <div class="container mx-auto w-full px-10 py-5">
+  <div class="container mx-auto w-full sm:px-10 py-5">
     <div class=" flex justify-center items-center">
       <%= render 'search_form', url: products_path %>
     </div>

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -1,5 +1,5 @@
 <%= render "shared/remote_modal", title: t('product.new.title') do %>
-  <div class="container mx-auto w-[540px] px-10 py-5">
+  <div class="container mx-auto w-full sm:w-[540px] px-10 py-5">
     <%= render 'form', product: @product %>
   </div>
 <% end %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -1,6 +1,6 @@
 <section class="overflow-hidden">
   <div class="container px-5 py-24 mx-auto">
-    <div class="flex w-1/2 justify-center mx-auto mb-20 rounded-lg border border-gray-400 p-8 gap-10">
+    <div class="flex flex-wrap w-full sm:w-1/2 justify-center mx-auto mb-20 rounded-lg border border-gray-400 p-8 gap-10">
       <div class="flex flex-col gap-2">
         <h1 class="text-3xl font-bold"><%= @product.name %></h1>
         <p><%= @product.brand.name %></p>

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -15,7 +15,7 @@
           <div class="flex mx-2 mt-2 gap-[24px] items-center justify-center">
             <% @review.images.each do |image| %>
               <div class ="flex flex-col items-center justify-center">
-                <%= image_tag image, class: "lg:w-[80px] w-full lg:h-[80px] h-64 object-fill object-center" %>
+                <%= image_tag image, class: "w-[60px] sm:w-[80px] h-[60px] sm:h-[80px] object-fill object-center" %>
                 <%=link_to review_attachment_path(@review.id, image.id), data: { turbo_method: :delete } do %>
                   <i class="fa-regular fa-circle-xmark"></i>
                 <% end %>

--- a/app/views/reviews/_review.html.erb
+++ b/app/views/reviews/_review.html.erb
@@ -1,16 +1,16 @@
-<div class="card card-side m-4 shadow" id="review-<%= review.id %>">
-  <div class="px-4 py-4 relative">
+<div class="card sm:card-side m-4 shadow" id="review-<%= review.id %>">
+  <div class="px-10 sm:px-4 py-4 sm:relative">
     <% if review.images.attached? %>
       <%= image_tag review.images[0], class: "h-[170px] w-[170px] rounded-lg" %>
     <% else %>
-      <%= image_tag 'kkrn_icon_shashin_3.png', class: "h-[170px] w-[170px] rounded-lg object-cover" %>
+      <%= image_tag 'kkrn_icon_shashin_3.png', class: "h-[170px] w-[170px] rounded-lg object-fit" %>
     <% end %>
     <% if review.images.count > 1 %>
-      <div class=" bg-black bg-opacity-50 absolute top-4 right-4 rounded-tr-lg rounded-bl-lg px-2">
+      <div class=" bg-black bg-opacity-50 absolute top-4 right-10 sm:right-4 rounded-tr-lg rounded-bl-lg px-2">
         <p class="text-white"><i class="fa-solid fa-images"></i> <%= review.images.count %></p>
       </div>
     <% end %>
-    <div class="card-actions justify-end mt-1">
+    <div class="card-actions sm:justify-end mt-1">
       <div class="flex gap-2">
         <%= link_to "https://twitter.com/share?url=#{post_review_url(review)}&text=【#{review.title}】%0a#{review.product.brand.name}%20#{review.product.name}のレビューをシェア%0a%0a%23インク沼%20%23iroGraphica%0a", title: "Xでシェア", target: :_blank, rel: "noopener noreferrer nofollow" do %>
           <i class="fa-brands fa-square-x-twitter text-[22px]"></i>
@@ -20,7 +20,7 @@
       </div>
     </div>
   </div>
-  <div class="card-body gap-0 flex-shrink-0 w-[340px] p-4">
+  <div class="card-body gap-0 flex-shrink-0 w-[250px] sm:w-[340px] p-4">
     <div class="card-title overflow-hidden mb-1 justify-between">
       <span class="w-3/4 text-[24px] font-bold text-ellipsis line-clamp-1"><%= review.title %></span>
       <% if review.user.avatar.attached? %>

--- a/app/views/reviews/edit.html.erb
+++ b/app/views/reviews/edit.html.erb
@@ -1,5 +1,5 @@
-<div class="container mx-auto w-[540px] px-10 py-5">
-  <h1 class="text-5xl font-bold text-center mb-10"><%= t('reviews.edit.title') %></h1>
+<div class="container mx-auto w-full sm:w-[540px] px-10 py-5">
+  <h1 class="text-[24px] sm:text-5xl font-bold text-center mb-10"><%= t('reviews.edit.title') %></h1>
   <%= render 'form', review: @review, images: @review.reload.images %>
   <div class="text-center mt-10">
     <%= link_to t('helpers.links.back'), 'javascript:history.back()', class: "btn btn-outline btn-primary" %>

--- a/app/views/reviews/new.html.erb
+++ b/app/views/reviews/new.html.erb
@@ -1,5 +1,5 @@
-<div class="container mx-auto w-[540px] px-10 py-5">
-  <h1 class="text-5xl font-bold text-center mb-10"><%= t('reviews.new.title') %></h1>
+<div class="container mx-auto w-full sm:w-[540px] px-10 py-5">
+  <h1 class="text-[24px] sm:text-5xl font-bold text-center mb-10"><%= t('reviews.new.title') %></h1>
   <%= render 'form', review: @review %>
   <div class="text-center mt-10">
     <%= link_to t('helpers.links.back'), 'javascript:history.back()', class: "btn btn-outline btn-primary" %>

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -1,31 +1,31 @@
 <section class="overflow-hidden">
   <div class="container px-5 py-10 mx-auto">
-    <div class="lg:w-4/5 mx-auto flex flex-wrap">
-      <div class="flex flex-col lg:w-1/2">
+    <div class="lg:w-4/5 mx-auto flex flex-wrap items-center justify-center">
+      <div class="flex flex-col lg:w-1/2 items-center justify-center">
         <% if @review.images.present? %>
-          <div style="--swiper-navigation-color: #fff; --swiper-pagination-color: #fff" class="swiper mySwiper2 lg:w-[350px] lg:h-[350px]">
+          <div style="--swiper-navigation-color: #fff; --swiper-pagination-color: #fff" class="swiper mySwiper2 w-[300px] sm:w-[350px] h-[300px] sm:h-[350px]">
             <div class="swiper-wrapper">
               <% @review.images.each do |image| %>
-                <%= image_tag image, class: "lg:w-[350px] w-full lg:h-[350px] h-64 object-cover object-center rounded swiper-slide" %>
+                <%= image_tag image, class: "w-[300px] sm:w-[350px] h-[300px] sm:h-[350px] object-cover object-center rounded swiper-slide mr-[30px]" %>
               <% end %>
             </div>
             <div class="swiper-button-next"></div>
             <div class="swiper-button-prev"></div>
           </div>
-          <div thumbsSlider="" class="swiper mySwiper lg:w-[350px] mt-1">
+          <div thumbsSlider="" class="swiper mySwiper w-[300px] sm:w-[350px] mt-1">
             <div class="swiper-wrapper">
               <% @review.images.each do |image| %>
-                <%= image_tag image, class: "lg:w-[80px] w-full lg:h-[80px] h-64 object-fill object-center rounded swiper-slide" %>
+                <%= image_tag image, class: "w-[60px] sm:w-[80px] h-[60px] sm:h-[80px] object-fill object-center rounded swiper-slide" %>
               <% end %>
             </div>
           </div>
         <% else %>
           <div>
-            <%= image_tag "kkrn_icon_shashin_3.png", class: "lg:w-[350px] w-full lg:h-[350px] h-64 object-cover object-center rounded mx-auto" %>
+            <%= image_tag "kkrn_icon_shashin_3.png", class: "w-[300px] sm:w-[350px] h-[300px] sm:h-[350px] object-cover object-center rounded mx-auto" %>
           </div>
         <% end %>
         <div class="mt-5 mx-auto">
-          <%= link_to "https://twitter.com/share?url=#{post_review_url(@review)}&text=【#{@review.title}】%0a#{@review.product.brand.name}%20#{@review.product.name}レビューをシェア%0a%0a%23インク沼%20%23iroGraphica%0a", title: "Xでシェア", class: "btn btn-neutral gap-0 w-[350px]", target: :_blank, rel: "noopener noreferrer nofollow" do %>
+          <%= link_to "https://twitter.com/share?url=#{post_review_url(@review)}&text=【#{@review.title}】%0a#{@review.product.brand.name}%20#{@review.product.name}のレビューをシェア%0a%0a%23インク沼%20%23iroGraphica%0a", title: "Xでシェア", class: "btn btn-neutral gap-0 w-[300px] sm:w-[350px]", target: :_blank, rel: "noopener noreferrer nofollow" do %>
             <i class="fa-brands fa-x-twitter text-[24px]"></i></i><span class="text-[20px]">でシェア</span>
           <% end %>
         </div>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,6 +1,6 @@
 <div class="flash" data-controller="flash">
   <% flash.each do |message_type, message| %>
-    <div role="alert" class="alert alert-<%= flash_type(message_type) %> w-1/2 mx-auto mt-2">
+    <div role="alert" class="alert alert-<%= flash_type(message_type) %> w-64 sm:w-1/2 mx-auto mt-2">
       <svg
         xmlns="http://www.w3.org/2000/svg"
         class="h-6 w-6 shrink-0 stroke-current"

--- a/app/views/shared/_remote_modal.html.erb
+++ b/app/views/shared/_remote_modal.html.erb
@@ -10,5 +10,8 @@
         <%= render 'shared/flash_message' %>
         <%= yield %>
     </div>
+    <form method="dialog" class="modal-backdrop">
+      <button>close</button>
+    </form>
   </div>
 <% end %>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with url: url, method: :get, local: true do |f| %>
+<%= form_with url: url, method: :get, local: true, class: "hidden sm:block" do |f| %>
   <div class="flex gap-1">
     <%= f.collection_select(:c, Category.all, :id, :color, {include_blank: t('category.select.include_blank')}, {class: "select select-bordered w-40 max-w-xs"}) %>
     <%= f.text_field :q, class: 'form-control input input-bordered w-full max-w-xs', placeholder: "キーワードで検索" %>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -1,7 +1,7 @@
-<%= form_with url: url, method: :get, local: true, class: "hidden sm:block" do |f| %>
-  <div class="flex gap-1">
-    <%= f.collection_select(:c, Category.all, :id, :color, {include_blank: t('category.select.include_blank')}, {class: "select select-bordered w-40 max-w-xs"}) %>
-    <%= f.text_field :q, class: 'form-control input input-bordered w-full max-w-xs', placeholder: "キーワードで検索" %>
-    <%= f.submit t('search.submit'), class: 'btn btn-primary' %>
+<%= form_with url: url, method: :get, local: true do |f| %>
+  <div class='flex gap-1'>
+    <%= f.collection_select(:c, Category.all, :id, :color, {include_blank: t('category.select.include_blank')}, {class: 'select select-bordered w-40 max-w-xs'}) %>
+    <%= f.text_field :q, class: 'form-control input input-bordered w-full max-w-xs', placeholder: 'キーワードで検索' %>
+    <%= f.submit t('search.submit'), class: 'btn btn-primary', data: { action: 'slideover#close' } %>
   </div>
 <% end %>

--- a/app/views/shared/_search_tab.html.erb
+++ b/app/views/shared/_search_tab.html.erb
@@ -21,15 +21,15 @@
     <%= @products.count %>件
   <% end %>
 </p>
-<div class="font-medium text-center text-gray-500 border-b border-gray-200 dark:text-gray-400 dark:border-gray-700 w-1/2 mx-auto mb-5">
+<div class="font-medium text-center text-gray-500 border-b border-gray-200 dark:text-gray-400 dark:border-gray-700 sm:w-1/2 mx-auto mb-5">
   <ul class="flex flex-wrap justify-center items-center -mb-px">
     <li>
       <%= link_to t('search.product'), search_products_path(q: params[:q], c: params[:c]),
-        class: "inline-block p-4 border-b-2 text-[32px] rounded-t-lg #{request.path.include?("products") ? "active_tabs" : "not_active_tabs"}" %>
+        class: "inline-block p-4 border-b-2 text-[16px] sm:text-[32px] rounded-t-lg #{request.path.include?("products") ? "active_tabs" : "not_active_tabs"}" %>
     </li>
     <li>
       <%= link_to t('search.review'), search_reviews_path(q: params[:q], c: params[:c]),
-        class: "inline-block p-4 border-b-2 text-[32px] rounded-t-lg #{request.path.include?("reviews") ? "active_tabs" : "not_active_tabs"}", "aria-current": "page" %>
+        class: "inline-block p-4 border-b-2 text-[16px] sm:text-[32px] rounded-t-lg #{request.path.include?("reviews") ? "active_tabs" : "not_active_tabs"}", "aria-current": "page" %>
     </li>
   </ul>
 </div>

--- a/app/views/static/home.html.erb
+++ b/app/views/static/home.html.erb
@@ -1,17 +1,17 @@
 <div class="container mx-auto px-5 py-5">
-  <div class="flex justify-center items-center h-[270px]">
-    <%= image_tag "irographica-biglogo.png", class: "h-[270px] w-[720px] object-cover flex-1" %>
+  <div class="flex flex-wrap justify-center items-center h-[270px]">
+    <%= image_tag "irographica-biglogo.png", class: "h-[270px] w-[370px] sm:w-[720px] object-contain sm:object-cover flex-1" %>
     <div class="text-center text-2xl flex-1 tracking-wider">
-      <p><%= simple_format(t('home.copywriting')) %></p>
+      <%= simple_format(t('home.copywriting')) %>
     </div>
   </div>
-  <div class="flex flex-wrap justify-center items-center gap-4 mt-2 mb-10">
+  <div class="flex flex-wrap justify-center items-center gap-4 pt-32 sm:pt-2 mb-10">
     <p><%= t('search.category') %></p>
     <% @category.each do |c| %>
       <%= link_to c.color, search_products_path(c: c.id), class: "link" %>
     <% end %>
   </div>
-  <h1 class="text-5xl font-bold text-center mb-10 tracking-wider"><%= t('home.see_review') %></h1>
+  <h1 class="text-[32px] sm:text-5xl font-bold text-center mb-10 tracking-wider"><%= t('home.see_review') %></h1>
   <div class="flex flex-wrap justify-center items-center p-5 gap-5">
     <% if @reviews.present? %>
       <%= render partial: 'reviews/review', collection: @reviews %>

--- a/app/views/users/_profile_header.html.erb
+++ b/app/views/users/_profile_header.html.erb
@@ -10,10 +10,8 @@
     <% else %>
       <%= image_tag 'kkrn_icon_user_1.png', class: "w-[150px] rounded-full mx-10 border-[2px] border-gray-200" %>
     <% end %>
-    <div class="mt-5 mx-auto items-center justify-center">
-      <%= link_to "https://twitter.com/share?url=#{post_profile_url(@user)}&text=#{@user.name}さんのプロフィール%0a%0a%23インク沼%20%23INKLOG", title: "Xでシェア", class: "btn btn-neutral gap-0 w-[110px]" do %>
-        <i class="fa-brands fa-x-twitter text-[16px]"></i></i><span class="text-[16px]">でシェア</span>
-      <% end %>
+    <div class="mt-5 mx-auto items-center justify-center hidden sm:block">
+      <%= render 'x_share' %>
     </div>
   </div>
   <div class="mx-10 flex flex-col">
@@ -38,6 +36,9 @@
           <i class="fa-brands fa-youtube text-[24px]"></i>
         <% end %>
       <% end %>
+    </div>
+    <div class="mt-5 mx-auto items-center justify-center sm:hidden">
+      <%= render 'x_share' %>
     </div>
   </div>
 </div>

--- a/app/views/users/_profile_tab.html.erb
+++ b/app/views/users/_profile_tab.html.erb
@@ -1,12 +1,12 @@
-<div class="font-medium text-center text-gray-500 border-b border-gray-200 dark:text-gray-400 dark:border-gray-700 w-1/2 mx-auto mb-5">
-  <ul class="flex flex-wrap justify-center items-center -mb-px">
+<div class="font-medium text-center text-gray-500 border-b border-gray-200 dark:text-gray-400 dark:border-gray-700 sm:w-1/2 mx-auto mb-5">
+  <ul class="flex justify-center items-center -mb-px">
     <li>
       <%= link_to t('users.show.current_user_reviews'), user_path(@user),
-        class: "inline-block p-4 border-b-2 text-[32px] rounded-t-lg #{request.path.include?("bookmarks") ? "not_active_tabs" : "active_tabs"}" %>
+        class: "inline-block p-4 border-b-2 text-[16px] sm:text-[32px] rounded-t-lg #{request.path.include?("bookmarks") ? "not_active_tabs" : "active_tabs"}" %>
     </li>
     <li>
       <%= link_to t('users.show.current_user_bookmarks'), bookmarks_user_path(@user),
-        class: "inline-block p-4 border-b-2 text-[32px] rounded-t-lg #{request.path.include?("bookmarks") ? "active_tabs" : "not_active_tabs"}", "aria-current": "page" %>
+        class: "inline-block p-4 border-b-2 text-[16px] sm:text-[32px] rounded-t-lg #{request.path.include?("bookmarks") ? "active_tabs" : "not_active_tabs"}", "aria-current": "page" %>
     </li>
   </ul>
 </div>

--- a/app/views/users/_x_share.html.erb
+++ b/app/views/users/_x_share.html.erb
@@ -1,0 +1,3 @@
+<%= link_to "https://twitter.com/share?url=#{post_profile_url(@user)}&text=#{@user.name}さんのプロフィール%0a%0a%23インク沼%20%23iroGraphica", title: "Xでシェア", class: "btn btn-neutral gap-0 w-[110px]" do %>
+  <i class="fa-brands fa-x-twitter text-[16px]"></i></i><span class="text-[16px]">でシェア</span>
+<% end %>

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.13",
-    "swiper": "^11.2.6"
+    "swiper": "^11.2.6",
+    "tailwindcss-stimulus-components": "^6.1.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -905,6 +905,11 @@ swiper@^11.2.6:
   resolved "https://registry.yarnpkg.com/swiper/-/swiper-11.2.6.tgz#826943bf87158518ca0b1f57d387272b12a07c52"
   integrity sha512-8aXpYKtjy3DjcbzZfz+/OX/GhcU5h+looA6PbAzHMZT6ESSycSp9nAjPCenczgJyslV+rUGse64LMGpWE3PX9Q==
 
+tailwindcss-stimulus-components@^6.1.3:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/tailwindcss-stimulus-components/-/tailwindcss-stimulus-components-6.1.3.tgz#c32b8b63e6e8b769057c37449510d15a9e403d40"
+  integrity sha512-2KAEOQkvFClER0SLxfgai19OCpAdFZomSfsiC1e8W+kz4GQRWAZQDnGzBOI03TwvPgI8wQTrLanUC1ugszEiJw==
+
 tailwindcss@3.4.17:
   version "3.4.17"
   resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.4.17.tgz#ae8406c0f96696a631c790768ff319d46d5e5a63"


### PR DESCRIPTION
# 実施タスク
closes #125 
アプリ全体をレスポンシブ対応

# 実施内容
- モバイル用とPC用でヘッダーをそれぞれ作成し、モバイル用のヘッダーは[tailwindcss-stimulus-components](https://github.com/excid3/tailwindcss-stimulus-components)のSlidoverを使用してハンバーガーメニューのサイドバーを表示するようにしました。
- モバイル用ヘッダーの検索フォームも[tailwindcss-stimulus-components](https://github.com/excid3/tailwindcss-stimulus-components)のSlidoverを使用して上からモーダルが表示されるようにしました。
- 全体的に`flex-wrap`を使用して、モバイル画面で回り込みで表示されるようにしています。
- モバイル画面表示時の文字サイズ・画像サイズも変更しています。
- プロフィールのXシェアボタンの位置をPCとモバイルで変えるのでパーシャル作りました。

# 備考
- ヘッダーはPCとモバイルとで配置が大幅に変わり、同じコードが複数の場所に書かれてわかりにくくなるので、別でパーシャルを作りました。PC画面用ヘッダーの変更点は`<div class="hidden sm:block">`で囲っただけです。
- 全体的に横並びのところを縦並びにしただけです。
- 一緒にインク選択モーダルも画面外クリックでモーダルが閉じるようにしています。
- サイドバーと検索フォームの閉じるアニメーションは現状なしです（`closing`でアニメーションが適用できない？ようなので）