### PR TITLE
静的OGPの追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,3 +76,5 @@ gem 'csv'
 
 gem "administrate"
 gem "administrate-field-active_storage"
+
+gem "meta-tags"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,6 +203,8 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    meta-tags (2.22.1)
+      actionpack (>= 6.0.0, < 8.1)
     mini_magick (5.2.0)
       benchmark
       logger
@@ -426,6 +428,7 @@ DEPENDENCIES
   image_processing (~> 1.2)
   jbuilder
   jsbundling-rails
+  meta-tags
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.2, >= 7.2.2.1)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,27 @@
 module ApplicationHelper
+  def default_meta_tags
+    {
+      site: 'iroGraphica',
+      title: '万年筆・ガラスペン用インクのレビュー投稿・共有サービス',
+      reverse: true,
+      charset: 'utf-8',
+      description: 'iroGraphicaは、万年筆・ガラスペン用インクのレビュー投稿・共有サービスです。インクのレビューを投稿したり、レビューやインクを色で検索することができます。',
+      keywords: '万年筆,ガラスペン,インク,インク沼,レビュー,共有',
+      canonical: 'https://irographica.com/',
+      separator: '|',
+      og:{
+        site_name: :site,
+        title: :title,
+        description: :description,
+        type: 'website',
+        url: 'https://irographica.com/',
+        image: image_url('irographica-staticOgp.png'),
+        local: 'ja-JP'
+      },
+      twitter: {
+        card: 'summary_large_image',
+        image: image_url('irographica-staticOgp.png')
+      }
+    }
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,6 +19,7 @@
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"></script>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+    <%= display_meta_tags(default_meta_tags) %>
   </head>
 
   <body class="body-font">

--- a/config/initializers/meta_tags.rb
+++ b/config/initializers/meta_tags.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Use this setup block to configure all options available in MetaTags.
+MetaTags.configure do |config|
+  # How many characters should the title meta tag have at most. Default is 70.
+  # Set to nil or 0 to remove limits.
+  # config.title_limit = 70
+
+  # When true, site title will be truncated instead of title. Default is false.
+  # config.truncate_site_title_first = false
+
+  # Add HTML attributes to the <title> HTML tag. Default is {}.
+  # config.title_tag_attributes = {}
+
+  # Natural separator when truncating. Default is " " (space character).
+  # Set to nil to disable natural separator.
+  # This also allows you to use a whitespace regular expression (/\s/) or
+  # a Unicode space (/\p{Space}/).
+  # config.truncate_on_natural_separator = " "
+
+  # Maximum length of the page description. Default is 300.
+  # Set to nil or 0 to remove limits.
+  # config.description_limit = 300
+
+  # Maximum length of the keywords meta tag. Default is 255.
+  # config.keywords_limit = 255
+
+  # Default separator for keywords meta tag (used when an Array passed with
+  # the list of keywords). Default is ", ".
+  # config.keywords_separator = ', '
+
+  # When true, keywords will be converted to lowercase, otherwise they will
+  # appear on the page as is. Default is true.
+  # config.keywords_lowercase = true
+
+  # When true, the output will not include new line characters between meta tags.
+  # Default is false.
+  # config.minify_output = false
+
+  # When false, generated meta tags will be self-closing (<meta ... />) instead
+  # of open (`<meta ...>`). Default is true.
+  # config.open_meta_tags = true
+
+  # List of additional meta tags that should use "property" attribute instead
+  # of "name" attribute in <meta> tags.
+  # config.property_tags.push(
+  #   'x-hearthstone:deck',
+  # )
+end


### PR DESCRIPTION
# 実施タスク
closes #126 
静的OGPを追加。

# 実施内容
- Gemfileに`gem 'meta-tags'`を追加しました
- meta-tagsの設定ファイルをインストールしました（特に変更なしです）
- app/helpers/application_helper.rbにmeta-tagsのオプションを定義しました
- app/views/layouts/application.html.erbにmeta-tagsを読み込む記述を追加しました

# 備考
とりあえず静的OGPのみです。動的OGPは後日実装します。
SEO対策のオプションも一緒に設定しています。