### PR TITLE
投稿フォームのオートコンプリート機能作成

### DIFF
--- a/app/views/products/_search_form.html.erb
+++ b/app/views/products/_search_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with url: url, method: :get, local: true do |f| %>
   <div class="flex gap-1">
-    <div data-controller="autocomplete" data-autocomplete-min-length-value="3" data-autocomplete-url-value="<%= autocomplete_products_path %>" role="combobox">
+    <div data-controller="autocomplete" autocomplete-delay-value="100" data-autocomplete-min-length-value="3" data-autocomplete-url-value="<%= autocomplete_products_path %>" role="combobox">
       <%= f.text_field :q, class: 'form-control input input-bordered w-full max-w-xs', data: { autocomplete_target: 'input' }, placeholder: 'キーワードで検索' %>
       <%= f.hidden_field :id, data: { autocomplete_target: 'hidden' } %>
       <ul class="list-group bg-base-100 absolute rounded-box z-[1] w-70 h-80 p-2 shadow overflow-y-auto overflow-x-hidden" data-autocomplete-target="results"></ul>

--- a/app/views/products/autocomplete.html.erb
+++ b/app/views/products/autocomplete.html.erb
@@ -1,14 +1,18 @@
-<% @products.each do |product| %>
-  <li class="flex items-center gap-x-3.5 py-2 px-3 w-50 sm:w-60 rounded-md text-sm text-gray-800 hover:bg-blue-200 focus:ring-2 focus:ring-blue-500 dark:text-gray-400 dark:hover:bg-blue-200 dark:hover:text-gray-300"
-    role="option"
-    data-autocomplete-value="<%= product.id %>">
-    <%= product.name %>
-  </li>
+<% if @products.present? %>
+  <% @products.each do |product| %>
+    <li class="flex items-center gap-x-3.5 py-2 px-3 w-50 sm:w-60 rounded-md text-sm text-gray-800 hover:bg-blue-200 focus:ring-2 focus:ring-blue-500 dark:text-gray-400 dark:hover:bg-blue-200 dark:hover:text-gray-300"
+      role="option"
+      data-autocomplete-value="<%= product.id %>">
+      <%= product.name %>
+    </li>
+  <% end %>
 <% end %>
-<% @brands.each do |brand| %>
-  <li class="flex items-center gap-x-3.5 py-2 px-3 w-50 sm:w-60 rounded-md text-sm text-gray-800 hover:bg-blue-200 focus:ring-2 focus:ring-blue-500 dark:text-gray-400 dark:hover:bg-blue-200 dark:hover:text-gray-300"
-    role="option"
-    data-autocomplete-value="<%= brand.id %>">
-    <%= brand.name %>
-  </li>
+<% if @brands.present? %>
+  <% @brands.each do |brand| %>
+    <li class="flex items-center gap-x-3.5 py-2 px-3 w-50 sm:w-60 rounded-md text-sm text-gray-800 hover:bg-blue-200 focus:ring-2 focus:ring-blue-500 dark:text-gray-400 dark:hover:bg-blue-200 dark:hover:text-gray-300"
+      role="option"
+      data-autocomplete-value="<%= brand.id %>">
+      <%= brand.name %>
+    </li>
+  <% end %>
 <% end %>

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -34,7 +34,11 @@
     <div class="flex flex-wrap -mx-3 mb-4">
       <div class="w-full px-3">
         <%= f.label :product_name, class: "px-3" %>
-        <%= f.text_field :product_name, value: @review.product&.name, class: "input input-bordered form-control mb-2 w-full mx-auto pl-2 text-base", data: { product_target: "name" } %>
+        <div data-controller="autocomplete" autocomplete-delay-value="100" data-autocomplete-min-length-value="3" data-autocomplete-url-value="<%= autocomplete_products_path %>" role="combobox">
+          <%= f.text_field :product_name, value: @review.product&.name, class: "input input-bordered form-control mb-2 w-full mx-auto pl-2 text-base", data: { product_target: "name", autocomplete_target: "input" } %>
+          <%= f.hidden_field :id, data: { autocomplete_target: 'hidden' } %>
+          <ul class="list-group bg-base-100 absolute rounded-box z-[1] w-70 h-80 p-2 shadow overflow-y-auto overflow-x-hidden" data-autocomplete-target="results"></ul>
+        </div>
       </div>
       <div class="w-full px-3">
         <%= link_to t('reviews.form.select_product'), products_path, class: "btn btn-primary w-full mx-auto", data: { turbo_frame: "remote_modal" } %>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with url: url, method: :get, local: true do |f| %>
   <div class='flex gap-1'>
     <%= f.collection_select(:c, Category.all, :id, :color, {include_blank: t('category.select.include_blank')}, {class: 'select select-bordered w-40 max-w-xs'}) %>
-    <div data-controller="autocomplete" data-autocomplete-min-length-value="3" data-autocomplete-url-value="<%= autocomplete_products_path %>" role="combobox">
+    <div data-controller="autocomplete" autocomplete-delay-value="100" data-autocomplete-min-length-value="3" data-autocomplete-url-value="<%= autocomplete_products_path %>" role="combobox">
       <%= f.text_field :q, class: 'form-control input input-bordered w-full max-w-xs', data: { autocomplete_target: 'input' }, placeholder: 'キーワードで検索' %>
       <%= f.hidden_field :id, data: { autocomplete_target: 'hidden' } %>
       <ul class="list-group bg-base-100 absolute rounded-box z-[1] w-70 h-80 p-2 shadow overflow-y-auto overflow-x-hidden" data-autocomplete-target="results"></ul>


### PR DESCRIPTION
# 実施タスク
closes #111 
レビュー投稿フォームのインク入力欄にオートコンプリート機能を実装

# 実施内容
- [x] app/views/reviews/new.html.erbを編集してオートコンプリート用のビューと投稿フォームを紐づける

# 備考
- #184 でオートコンプリートをインク名とメーカー名のみに絞ったので、#184 で作成したオートコンプリート機能を流用して、ビューとレビュー投稿フォームのインク入力欄を紐づけました。
- 検索ワードを入力してからオートコンプリートが表示されるまでの時間が、デフォルトの300ミリ秒だと少し遅いと感じたので、100ミリ秒に変更してます。
- オートコンプリートのビューに存在チェックのコードがなかったので追加しました。
- 本来ならBrandの結果は出すべきではないですが、例えば遷移元URLが`reviews/new`の時はBrandのみ実行しない、というような条件分岐を組むとヘッダーの検索フォームにも影響が出てしまうので、今はこのままにしています。登録されているインク以外が入力されたらバリデーションエラーになるので、とりあえずこのままで支障はないかと思います（余計なクエリが発行されてしまいますが…）。