### PR TITLE
fix: モバイルブラウザでdialog要素の閉じるボタンに黒枠が出る問題を修正

### DIFF
--- a/app/views/layouts/_mobile_header.html.erb
+++ b/app/views/layouts/_mobile_header.html.erb
@@ -20,7 +20,7 @@
                 </div>
                 <%= current_user.name %>
               </div>
-                <%= link_to new_review_path, class: "btn btn-wide btn-secondary", data: { action: "slideover#close" } do %>
+                <%= link_to new_review_path, class: "btn btn-wide btn-secondary", autofocus: true, data: { action: "slideover#close" } do %>
                   <i class="fa-solid fa-pen-to-square"></i>
                   <span><%= t('header.post') %></span>
                 <% end %>
@@ -28,7 +28,7 @@
                 <%= link_to t('header.notification'), "#", data: { action: "slideover#close" } %>
                 <%= link_to t('header.sign_out'), destroy_user_session_path, data: { turbo_method: :delete, action: "slideover#close" } %>
             <% else %>
-                <%= link_to t('header.sign_in'), user_session_path, class: "btn btn-wide btn-primary", data: { action: "slideover#close" } %>
+                <%= link_to t('header.sign_in'), user_session_path, class: "btn btn-wide btn-primary", autofocus: true, data: { action: "slideover#close" } %>
                 <%= link_to t('header.to_register_page'), new_user_registration_path, class: "btn btn-wide btn-secondary", data: { action: "slideover#close" } %>
             <% end %>
           </div>

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -3,7 +3,7 @@
   <div class="flex flex-wrap -mx-3 mb-4">
     <div class="w-full px-3">
       <%= f.label :name, class: "px-3" %>
-      <%= f.text_field :name, class: "input input-bordered form-control w-full mx-auto pl-2 text-base" %>
+      <%= f.text_field :name, class: "input input-bordered form-control w-full mx-auto pl-2 text-base", autofocus: true %>
     </div>
   </div>
   <div class="flex flex-wrap -mx-3 mb-4">

--- a/app/views/products/_search_form.html.erb
+++ b/app/views/products/_search_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with url: url, method: :get, local: true do |f| %>
   <div class="flex gap-1">
     <div data-controller="autocomplete" autocomplete-delay-value="100" data-autocomplete-min-length-value="3" data-autocomplete-url-value="<%= autocomplete_products_path %>" role="combobox">
-      <%= f.text_field :q, class: 'form-control input input-bordered w-full max-w-xs', data: { autocomplete_target: 'input' }, placeholder: 'キーワードで検索' %>
+      <%= f.text_field :q, class: 'form-control input input-bordered w-full max-w-xs', data: { autocomplete_target: 'input' }, placeholder: 'キーワードで検索', autofocus: true %>
       <%= f.hidden_field :id, data: { autocomplete_target: 'hidden' } %>
       <ul class="list-group bg-base-100 absolute rounded-box z-[1] w-70 h-80 p-2 shadow overflow-y-auto overflow-x-hidden" data-autocomplete-target="results"></ul>
     </div>

--- a/app/views/products/autocomplete.html.erb
+++ b/app/views/products/autocomplete.html.erb
@@ -1,6 +1,6 @@
 <% if @products.present? %>
   <% @products.each do |product| %>
-    <li class="flex items-center gap-x-3.5 py-2 px-3 w-50 sm:w-60 rounded-md text-sm text-gray-800 hover:bg-blue-200 focus:ring-2 focus:ring-blue-500 dark:text-gray-400 dark:hover:bg-blue-200 dark:hover:text-gray-300"
+    <li class="flex items-center gap-x-3.5 py-2 px-3 w-50 sm:w-60 rounded-md text-sm hover:bg-blue-200 focus:ring-2 focus:ring-blue-500"
       role="option"
       data-autocomplete-value="<%= product.id %>">
       <%= product.name %>
@@ -9,7 +9,7 @@
 <% end %>
 <% if @brands.present? %>
   <% @brands.each do |brand| %>
-    <li class="flex items-center gap-x-3.5 py-2 px-3 w-50 sm:w-60 rounded-md text-sm text-gray-800 hover:bg-blue-200 focus:ring-2 focus:ring-blue-500 dark:text-gray-400 dark:hover:bg-blue-200 dark:hover:text-gray-300"
+    <li class="flex items-center gap-x-3.5 py-2 px-3 w-50 sm:w-60 rounded-md text-sm hover:bg-blue-200 focus:ring-2 focus:ring-blue-500"
       role="option"
       data-autocomplete-value="<%= brand.id %>">
       <%= brand.name %>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -2,7 +2,7 @@
   <div class='flex gap-1'>
     <%= f.collection_select(:c, Category.all, :id, :color, {include_blank: t('category.select.include_blank')}, {class: 'select select-bordered w-40 max-w-xs'}) %>
     <div data-controller="autocomplete" autocomplete-delay-value="100" data-autocomplete-min-length-value="3" data-autocomplete-url-value="<%= autocomplete_products_path %>" role="combobox">
-      <%= f.text_field :q, class: 'form-control input input-bordered w-full max-w-xs', data: { autocomplete_target: 'input' }, placeholder: 'キーワードで検索' %>
+      <%= f.text_field :q, class: 'form-control input input-bordered w-full max-w-xs', data: { autocomplete_target: 'input' }, placeholder: 'キーワードで検索', autofocus: true %>
       <%= f.hidden_field :id, data: { autocomplete_target: 'hidden' } %>
       <ul class="list-group bg-base-100 absolute rounded-box z-[1] w-70 h-80 p-2 shadow overflow-y-auto overflow-x-hidden" data-autocomplete-target="results"></ul>
     </div>


### PR DESCRIPTION
# 実施タスク
- モバイルブラウザでdialog要素の閉じるボタンに黒枠が出る問題の対応
- 不要なスタイルの削除

# 実施内容
- app/views/layouts/_mobile_header.html.erb、app/views/products/_form.html.erb、app/views/products/_search_form.html.erb、app/views/shared/_search_form.html.erbの、最初にフォーカスしてほしい要素に`autofocus: true`を設定
- app/views/products/autocomplete.html.erbの消し忘れてた不要なスタイルを削除

# 備考
Safariでdialog要素を使用している部分を表示させた際に、閉じるボタンに黒枠が表示されてしまっていたので修正しました。
dialog要素は
> [HTMLDialogElement.showModal()](https://developer.mozilla.org/ja/docs/Web/API/HTMLDialogElement/showModal) を用いて <dialog> を開いたとき、フォーカスは内部で最初のフォーカス可能な要素に設定されます。
https://developer.mozilla.org/ja/docs/Web/HTML/Reference/Elements/dialog
  
とのことだったので、dialogを開いたときにフォーカスしてほしい要素に`autofocus: true`を設定することで対応しています。
サイドバーではログインか投稿ボタンに、それ以外は入力フォームにフォーカスするようにしました。
開発者モードでは確認できないので、デプロイ後にスマホで確認します。