### PR TITLE
fix: link_toのautofocusが効いてないのでdialog要素にautofocusを設定

### DIFF
--- a/app/views/layouts/_mobile_header.html.erb
+++ b/app/views/layouts/_mobile_header.html.erb
@@ -2,7 +2,7 @@
   <div class="navbar bg-base-100 border-b border-primary h-[70px]">
     <div class="navbar-start">
       <div data-controller="slideover">
-        <dialog data-slideover-target="dialog" data-action="click->slideover#backdropClose" class="slideover h-full max-h-full m-0 w-[344px] p-4 backdrop:bg-black/30">
+        <dialog data-slideover-target="dialog" data-action="click->slideover#backdropClose" class="slideover h-full max-h-full m-0 w-[344px] p-4 backdrop:bg-black/30" autofocus>
           <div class="flex justify-end items-center">
             <button autofocus data-action="slideover#close" class="btn btn-ghost btn-circle text-sm">✕</button>
           </div>
@@ -20,7 +20,7 @@
                 </div>
                 <%= current_user.name %>
               </div>
-                <%= link_to new_review_path, class: "btn btn-wide btn-secondary", autofocus: true, data: { action: "slideover#close" } do %>
+                <%= link_to new_review_path, class: "btn btn-wide btn-secondary", data: { action: "slideover#close" } do %>
                   <i class="fa-solid fa-pen-to-square"></i>
                   <span><%= t('header.post') %></span>
                 <% end %>
@@ -28,7 +28,7 @@
                 <%= link_to t('header.notification'), "#", data: { action: "slideover#close" } %>
                 <%= link_to t('header.sign_out'), destroy_user_session_path, data: { turbo_method: :delete, action: "slideover#close" } %>
             <% else %>
-                <%= link_to t('header.sign_in'), user_session_path, class: "btn btn-wide btn-primary", autofocus: true, data: { action: "slideover#close" } %>
+                <%= link_to t('header.sign_in'), user_session_path, class: "btn btn-wide btn-primary", data: { action: "slideover#close" } %>
                 <%= link_to t('header.to_register_page'), new_user_registration_path, class: "btn btn-wide btn-secondary", data: { action: "slideover#close" } %>
             <% end %>
           </div>


### PR DESCRIPTION
# 実施タスク
モバイルブラウザでdialog要素の閉じるボタンに黒枠が出る問題の対応

# 実施内容
- app/views/layouts/_mobile_header.html.erbのオートフォーカスの設定がlink_toだと効いていなかったので、dialog要素に移動。

# 備考
スマホで確認したところ、formに追加したautofocusは機能していましたが、サイドバーのlink_toに設定したautofocusが機能していなかったので、dialog要素に移動してみました。
https://developer.mozilla.org/ja/docs/Web/HTML/Reference/Elements/dialog
> 他に即座の操作が想定される要素がない場合は、autofocus をダイアログ内の［閉じる］ボタンに追加するか、ユーザーがクリック/アクティブにして閉じることが想定される場合はダイアログ自体に追加することをお勧めします。