### PR TITLE
fix: focus-visibleを0に設定してみる

### DIFF
--- a/app/views/layouts/_mobile_header.html.erb
+++ b/app/views/layouts/_mobile_header.html.erb
@@ -2,7 +2,7 @@
   <div class="navbar bg-base-100 border-b border-primary h-[70px]">
     <div class="navbar-start">
       <div data-controller="slideover">
-        <dialog data-slideover-target="dialog" data-action="click->slideover#backdropClose" class="slideover h-full max-h-full m-0 w-[344px] p-4 backdrop:bg-black/30" autofocus>
+        <dialog data-slideover-target="dialog" data-action="click->slideover#backdropClose" class="slideover h-full max-h-full m-0 w-[344px] p-4 backdrop:bg-black/30 focus-visible:ring-0" autofocus>
           <div class="flex justify-end items-center">
             <button autofocus data-action="slideover#close" class="btn btn-ghost btn-circle text-sm">✕</button>
           </div>


### PR DESCRIPTION
# 実装タスク
サイドバーを開いたときに、dialogの境界に青い線が出る問題を修正

# 実装内容
- サイドバーのdialogに`focus-visible:ring-0`を設定してみて青い線が消えるかを確認する

# 備考
デフォルトがringらしいので、ring-0で線が消えるか試してみます。