### PR TITLE
Improve style

### DIFF
--- a/app/views/layouts/_mobile_header.html.erb
+++ b/app/views/layouts/_mobile_header.html.erb
@@ -2,9 +2,9 @@
   <div class="navbar bg-base-100 border-b border-primary h-[70px]">
     <div class="navbar-start">
       <div data-controller="slideover">
-        <dialog data-slideover-target="dialog" data-action="click->slideover#backdropClose" class="slideover h-full max-h-full m-0 w-[344px] p-4 backdrop:bg-black/30 focus-visible:ring-0" autofocus>
+        <dialog data-slideover-target="dialog" data-action="click->slideover#backdropClose" class="slideover h-full max-h-full m-0 w-[344px] p-4 backdrop:bg-black/30" autofocus>
           <div class="flex justify-end items-center">
-            <button autofocus data-action="slideover#close" class="btn btn-ghost btn-circle text-sm">✕</button>
+            <button autofocus data-action="slideover#close" class="btn btn-ghost btn-circle text-sm focus:outline-none">✕</button>
           </div>
           <div class="flex flex-col justify-center items-center gap-4 border-b border-black pb-4">
             <% if user_signed_in? %>

--- a/app/views/layouts/_mobile_header.html.erb
+++ b/app/views/layouts/_mobile_header.html.erb
@@ -2,7 +2,7 @@
   <div class="navbar bg-base-100 border-b border-primary h-[70px]">
     <div class="navbar-start">
       <div data-controller="slideover">
-        <dialog data-slideover-target="dialog" data-action="click->slideover#backdropClose" class="slideover h-full max-h-full m-0 w-[344px] p-4 backdrop:bg-black/30" autofocus>
+        <dialog data-slideover-target="dialog" data-action="click->slideover#backdropClose" class="slideover h-full max-h-full m-0 w-[344px] p-4 backdrop:bg-black/30">
           <div class="flex justify-end items-center">
             <button autofocus data-action="slideover#close" class="btn btn-ghost btn-circle text-sm focus:outline-none">✕</button>
           </div>


### PR DESCRIPTION
# 実装タスク
モバイルブラウザでサイドバーを表示したときに青い線が出る問題を修正

# 実施内容
- サイドバーの閉じるボタンに`focus:outlone-none`を設定
- dialogのautofocusを削除

# 備考
 #188 の対応では青い線が消えなかったので、閉じるボタンに`focus:outlone-none`を設定してフォーカスリングが表示されないようにしてみました。
開発者モードでTabキーで表示を確認しましたが、フォーカスリングは出なかったので多分これでいけると思います。
併せてdialogのautofocusを削除しています。