### PR TITLE
インク登録フォームにオートコンプリート機能追加

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -58,9 +58,21 @@ class ProductsController < ApplicationController
   end
 
   def autocomplete
-    @q = params[:q]
-    @products = Product.ransack(name_cont: @q).result(distinct: true)
-    @brands = Brand.ransack(name_cont: @q).result(distinct: true)
+    case
+    # 検索フォーム用
+    when params[:q]
+      @q = params[:q]
+      @products = Product.ransack(name_cont: @q).result(distinct: true)
+      @brands = Brand.ransack(name_cont: @q).result(distinct: true)
+    # インクのみ検索（投稿フォーム入力欄＆インク登録欄）
+    when params[:product_name]
+      @q = params[:product_name]
+      @products = Product.ransack(name_cont: @q).result(distinct: true)
+    # メーカー名のみ検索（インク登録欄）
+    when params[:brand_name]
+      @q = params[:brand_name]
+      @brands = Brand.ransack(name_cont: @q).result(distinct: true)
+    end
     render layout: "main_only"
   end
 

--- a/app/views/layouts/_mobile_header.html.erb
+++ b/app/views/layouts/_mobile_header.html.erb
@@ -68,10 +68,8 @@
     <div class="navbar-end">
       <div data-controller="slideover">
         <dialog data-slideover-target="dialog"  data-action="click->slideover#backdropClose" class="slideover-search overflow-visible w-full max-w-full m-0 h-[140px] p-4 backdrop:bg-black/30">
-          <div class="mt-6">
-            <%= render 'shared/search_form', url: search_reviews_path %>
-          </div>
-          <div class="flex justify-end mt-2">
+          <%= render 'shared/search_form', url: search_reviews_path %>
+          <div class="absolute top-24 right-1">
             <button autofocus data-action="slideover#close" class="btn btn-ghost btn-circle text-sm">✕</button>
           </div>
         </dialog>

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -3,7 +3,7 @@
   <div class="flex flex-wrap -mx-3 mb-4">
     <div class="w-full px-3">
       <%= f.label :name, class: "px-3" %>
-      <div data-controller="autocomplete" autocomplete-delay-value="100" data-autocomplete-min-length-value="3" data-autocomplete-url-value="<%= autocomplete_products_path %>" role="combobox">
+      <div data-controller="autocomplete" data-autocomplete-query-param-value="product_name" autocomplete-delay-value="100" data-autocomplete-min-length-value="3" data-autocomplete-url-value="<%= autocomplete_products_path %>" role="combobox">
         <%= f.text_field :name, class: "input input-bordered form-control w-full mx-auto pl-2 text-base", data: { autocomplete_target: 'input' }, autofocus: true %>
         <%= f.hidden_field :id, data: { autocomplete_target: 'hidden' } %>
         <ul class="list-group bg-base-100 absolute rounded-box z-[1] w-70 h-80 p-2 shadow overflow-y-auto overflow-x-hidden" data-autocomplete-target="results"></ul>
@@ -13,7 +13,7 @@
   <div class="flex flex-wrap -mx-3 mb-4">
     <div class="w-full px-3">
       <%= f.label :brand_name, class: "px-3" %>
-      <div data-controller="autocomplete" autocomplete-delay-value="100" data-autocomplete-min-length-value="3" data-autocomplete-url-value="<%= autocomplete_products_path %>" role="combobox">
+      <div data-controller="autocomplete" data-autocomplete-query-param-value="brand_name" autocomplete-delay-value="100" data-autocomplete-min-length-value="3" data-autocomplete-url-value="<%= autocomplete_products_path %>" role="combobox">
         <%= f.text_field :brand_name, class: "input input-bordered form-control w-full mx-auto pl-2 text-base", data: { autocomplete_target: 'input' } %>
         <%= f.hidden_field :id, data: { autocomplete_target: 'hidden' } %>
         <ul class="list-group bg-base-100 absolute rounded-box z-[1] w-70 h-80 p-2 shadow overflow-y-auto overflow-x-hidden" data-autocomplete-target="results"></ul>

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -3,13 +3,21 @@
   <div class="flex flex-wrap -mx-3 mb-4">
     <div class="w-full px-3">
       <%= f.label :name, class: "px-3" %>
-      <%= f.text_field :name, class: "input input-bordered form-control w-full mx-auto pl-2 text-base", autofocus: true %>
+      <div data-controller="autocomplete" autocomplete-delay-value="100" data-autocomplete-min-length-value="3" data-autocomplete-url-value="<%= autocomplete_products_path %>" role="combobox">
+        <%= f.text_field :name, class: "input input-bordered form-control w-full mx-auto pl-2 text-base", data: { autocomplete_target: 'input' }, autofocus: true %>
+        <%= f.hidden_field :id, data: { autocomplete_target: 'hidden' } %>
+        <ul class="list-group bg-base-100 absolute rounded-box z-[1] w-70 h-80 p-2 shadow overflow-y-auto overflow-x-hidden" data-autocomplete-target="results"></ul>
+      </div>
     </div>
   </div>
   <div class="flex flex-wrap -mx-3 mb-4">
     <div class="w-full px-3">
       <%= f.label :brand_name, class: "px-3" %>
-      <%= f.text_field :brand_name, class: "input input-bordered form-control w-full mx-auto pl-2 text-base" %>
+      <div data-controller="autocomplete" autocomplete-delay-value="100" data-autocomplete-min-length-value="3" data-autocomplete-url-value="<%= autocomplete_products_path %>" role="combobox">
+        <%= f.text_field :brand_name, class: "input input-bordered form-control w-full mx-auto pl-2 text-base", data: { autocomplete_target: 'input' } %>
+        <%= f.hidden_field :id, data: { autocomplete_target: 'hidden' } %>
+        <ul class="list-group bg-base-100 absolute rounded-box z-[1] w-70 h-80 p-2 shadow overflow-y-auto overflow-x-hidden" data-autocomplete-target="results"></ul>
+      </div>
     </div>
   </div>
   <div class="flex flex-wrap -mx-3 mb-4">

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -34,7 +34,7 @@
     <div class="flex flex-wrap -mx-3 mb-4">
       <div class="w-full px-3">
         <%= f.label :product_name, class: "px-3" %>
-        <div data-controller="autocomplete" autocomplete-delay-value="100" data-autocomplete-min-length-value="3" data-autocomplete-url-value="<%= autocomplete_products_path %>" role="combobox">
+        <div data-controller="autocomplete" data-autocomplete-query-param-value="product_name" autocomplete-delay-value="100" data-autocomplete-min-length-value="3" data-autocomplete-url-value="<%= autocomplete_products_path %>" role="combobox">
           <%= f.text_field :product_name, value: @review.product&.name, class: "input input-bordered form-control mb-2 w-full mx-auto pl-2 text-base", data: { product_target: "name", autocomplete_target: "input" } %>
           <%= f.hidden_field :id, data: { autocomplete_target: 'hidden' } %>
           <ul class="list-group bg-base-100 absolute rounded-box z-[1] w-70 h-80 p-2 shadow overflow-y-auto overflow-x-hidden" data-autocomplete-target="results"></ul>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -1,8 +1,8 @@
 <%= form_with url: url, method: :get, local: true do |f| %>
-  <div class='flex gap-1'>
+  <div class='flex flex-wrap gap-1'>
     <%= f.collection_select(:c, Category.all, :id, :color, {include_blank: t('category.select.include_blank')}, {class: 'select select-bordered w-40 max-w-xs'}) %>
     <div data-controller="autocomplete" autocomplete-delay-value="100" data-autocomplete-min-length-value="3" data-autocomplete-url-value="<%= autocomplete_products_path %>" role="combobox">
-      <%= f.text_field :q, class: 'form-control input input-bordered w-full max-w-xs', data: { autocomplete_target: 'input' }, placeholder: 'キーワードで検索', autofocus: true %>
+      <%= f.text_field :q, class: 'form-control input input-bordered w-60 sm:w-full sm:max-w-xs', data: { autocomplete_target: 'input' }, placeholder: 'キーワードで検索', autofocus: true %>
       <%= f.hidden_field :id, data: { autocomplete_target: 'hidden' } %>
       <ul class="list-group bg-base-100 absolute rounded-box z-[1] w-70 h-80 p-2 shadow overflow-y-auto overflow-x-hidden" data-autocomplete-target="results"></ul>
     </div>


### PR DESCRIPTION
# 実施タスク
closes #111 
インク登録フォームのオートコンプリート対応をやり忘れてたので実施。

# 実施内容
- インク登録フォームの入力欄にオートコンプリート機能を追加しました。
- `autocomplete`アクションのコードを修正して、パラメータのキーでどのモデルを検索するかを条件分岐するようにしました。
- 修正したと思っていた検索フォームのデザインが修正されていなかったので（？）修正しました。

# 備考
- Stimulus-autocompleteは`data-autocomplete-query-param-value`を設定すると`q`以外のクエリパラメータが使えるので、ヘッダーの検索フォームはデフォルト（`q`）、投稿フォームのインク入力欄及びインク新規登録フォームのインク名入力欄には`product_name`、インク登録フォームのメーカー名入力欄には`brand_name`を設定して、コントローラに送られたキーでどのモデルを検索するか条件分岐するようにしました。
`q`はProductとBrand、`product_name`はProduct、`brand_name`はBrandを検索します。
これにより、インク名のみ表示したい場所はProductのみ検索、メーカー名のみ表示したい場所はBrandのみ検索できるようになりました。
- 昨日修正したはずのモバイルでの検索フォームのデザイン修正がなかったことになっていたので（？）修正しました。