### PR TITLE
投稿フォームにインクレシピ入力欄追加

### DIFF
--- a/app/controllers/ink_recipes_controller.rb
+++ b/app/controllers/ink_recipes_controller.rb
@@ -1,0 +1,2 @@
+class InkRecipesController < ApplicationController
+end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -5,6 +5,7 @@ class ReviewsController < ApplicationController
 
   def new
     @review = Review.new
+    @review.ink_recipes.build
   end
 
   def create

--- a/app/helpers/ink_recipes_helper.rb
+++ b/app/helpers/ink_recipes_helper.rb
@@ -1,0 +1,2 @@
+module InkRecipesHelper
+end

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,8 +1,10 @@
 import { Application } from "@hotwired/stimulus"
 import { Autocomplete } from 'stimulus-autocomplete'
+import RailsNestedForm from '@stimulus-components/rails-nested-form'
 
 const application = Application.start()
 application.register('autocomplete', Autocomplete)
+application.register('nested-form', RailsNestedForm)
 
 // Configure Stimulus development experience
 application.debug = false

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -10,6 +10,9 @@ application.register("flash", FlashController)
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 
+import NestedFormController from "./nested_form_controller"
+application.register("nested-form", NestedFormController)
+
 import ProductController from "./product_controller"
 application.register("product", ProductController)
 

--- a/app/javascript/controllers/nested_form_controller.js
+++ b/app/javascript/controllers/nested_form_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="nested-form"
+export default class extends Controller {
+  connect() {
+  }
+}

--- a/app/javascript/controllers/nested_form_controller.js
+++ b/app/javascript/controllers/nested_form_controller.js
@@ -6,7 +6,7 @@ export default class extends NestedForm {
     super.connect()
   }
 
-  openRecipe(e) {
+  openRecipe() {
     if (this.nameTarget.value.startsWith("オリジナル")) {
       this.recipeTarget.classList.remove("hidden");
     } else {

--- a/app/javascript/controllers/nested_form_controller.js
+++ b/app/javascript/controllers/nested_form_controller.js
@@ -1,7 +1,18 @@
 import NestedForm from "@stimulus-components/rails-nested-form"
 
 export default class extends NestedForm {
+  static targets = ["target", "template", "recipe", "name"]
   connect() {
     super.connect()
+  }
+
+  openRecipe(e) {
+    if (this.nameTarget.value.startsWith("オリジナル")) {
+      this.recipeTarget.classList.remove("hidden");
+    } else {
+      if (!this.recipeTarget.classList.contains("hidden")) {
+        this.recipeTarget.classList.add("hidden");
+      }
+    };
   }
 }

--- a/app/javascript/controllers/nested_form_controller.js
+++ b/app/javascript/controllers/nested_form_controller.js
@@ -1,7 +1,7 @@
-import { Controller } from "@hotwired/stimulus"
+import NestedForm from "@stimulus-components/rails-nested-form"
 
-// Connects to data-controller="nested-form"
-export default class extends Controller {
+export default class extends NestedForm {
   connect() {
+    super.connect()
   }
 }

--- a/app/javascript/controllers/product_controller.js
+++ b/app/javascript/controllers/product_controller.js
@@ -9,5 +9,8 @@ export default class extends Controller {
   select(e) {
     const button = e.currentTarget
     this.nameTarget.value = button.dataset.name;
+
+    const event = new Event("change");
+    this.nameTarget.dispatchEvent(event);
   }
 }

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -4,8 +4,8 @@ class Review < ApplicationRecord
   has_many_attached :images
   has_many :likes, dependent: :destroy
   has_many :bookmarks, dependent: :destroy
-  has_many :ink_recipe, dependent: :destroy
-  accepts_nested_attributes_for :ink_recipe, reject_if: :all_blank, allow_destroy: true
+  has_many :ink_recipes, dependent: :destroy
+  accepts_nested_attributes_for :ink_recipes, reject_if: :all_blank, allow_destroy: true
 
   validates :title, presence: true, length: { maximum: 20 }
   validates :body, presence: true, length: { maximum: 2000 }

--- a/app/views/ink_recipes/_recipe_form.html.erb
+++ b/app/views/ink_recipes/_recipe_form.html.erb
@@ -1,9 +1,9 @@
 <div class="nested-form-wrapper flex flex-wrap gap-2" data-new-record="<%= f.object.new_record? %>">
   <div class="w-[180px] sm:w-[320px] md:mb-0">
-    <%= f.text_field :name, class: "input input-bordered form-control mb-2 w-full mx-auto pl-2 text-base", placeholder: "使用したインク" %>
+    <%= f.text_field :name, class: "input input-bordered form-control mb-2 w-full mx-auto pl-2 text-base", placeholder: t('reviews.form.ink_recipe_name') %>
   </div>
   <div class="w-[70px] sm:w-[100px] md:mb-0">
-    <%= f.number_field :amount, step: "0.1", class: "input input-bordered form-control mb-2 w-full mx-auto pl-2 pr-6", placeholder: "配合量" %>
+    <%= f.number_field :amount, step: "0.1", class: "input input-bordered form-control mb-2 w-full mx-auto pl-2 pr-6", placeholder: t('reviews.form.ink_recipe_amount') %>
   </div>
   <button type="button" data-action="nested-form#remove"><i class="fa-regular fa-circle-xmark"></i></button>
 

--- a/app/views/ink_recipes/_recipe_form.html.erb
+++ b/app/views/ink_recipes/_recipe_form.html.erb
@@ -1,0 +1,11 @@
+<div class="nested-form-wrapper flex flex-wrap gap-2" data-new-record="<%= f.object.new_record? %>">
+  <div class="w-[180px] sm:w-[320px] md:mb-0">
+    <%= f.text_field :name, class: "input input-bordered form-control mb-2 w-full mx-auto pl-2 text-base", placeholder: "使用したインク" %>
+  </div>
+  <div class="w-[70px] sm:w-[100px] md:mb-0">
+    <%= f.number_field :amount, step: "0.1", class: "input input-bordered form-control mb-2 w-full mx-auto pl-2 pr-6", placeholder: "配合量" %>
+  </div>
+  <button type="button" data-action="nested-form#remove"><i class="fa-regular fa-circle-xmark"></i></button>
+
+  <%= f.hidden_field :_destroy %>
+</div>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,11 +1,11 @@
 <nav class="grid-flow-col gap-4">
-  <%= link_to "お問い合わせ", contact_path %>
+  <%= link_to t('footer.contact'), contact_path %>
   <!-- ページ作成後使用
   <%= link_to '利用規約', '#' %>
   <%= link_to 'プライバシーポリシー', '#' %>
   -->
   <% if current_user&.admin? %>
-    <%= link_to "管理", admin_root_path %>
+    <%= link_to t('footer.admin'), admin_root_path %>
   <% end %>
 </nav>
 

--- a/app/views/layouts/_mobile_header.html.erb
+++ b/app/views/layouts/_mobile_header.html.erb
@@ -33,13 +33,13 @@
             <% end %>
           </div>
           <div class="flex flex-col justify-center items-center mt-10 gap-2">
-            <%= link_to "お問い合わせ", contact_path, data: { action: "slideover#close" } %>
+            <%= link_to t('footer.contact'), contact_path, data: { action: "slideover#close" } %>
             <!-- ページ作成後使用
             <%= link_to '利用規約', '#' %>
             <%= link_to 'プライバシーポリシー', '#' %>
             -->
             <% if current_user&.admin? %>
-              <%= link_to "管理", admin_root_path, data: { action: "slideover#close" } %>
+              <%= link_to t('footer.admin'), admin_root_path, data: { action: "slideover#close" } %>
             <% end %>
             <p>© 2025 iroGraphica.</p>
           </div>

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -35,7 +35,7 @@
       <div class="w-full px-3">
         <%= f.label :product_name, class: "px-3" %>
         <div data-controller="autocomplete" data-autocomplete-query-param-value="product_name" autocomplete-delay-value="100" data-autocomplete-min-length-value="3" data-autocomplete-url-value="<%= autocomplete_products_path %>" role="combobox">
-          <%= f.text_field :product_name, value: @review.product&.name, class: "input input-bordered form-control mb-2 w-full mx-auto pl-2 text-base", data: { product_target: "name", autocomplete_target: "input" } %>
+          <%= f.text_field :product_name, value: @review.product&.name, class: "input input-bordered form-control mb-2 w-full mx-auto pl-2 text-base", data: { product_target: "name", autocomplete_target: "input", nested_form_target: "name", action: "change->nested-form#openRecipe" } %>
           <%= f.hidden_field :id, data: { autocomplete_target: 'hidden' } %>
           <ul class="list-group bg-base-100 absolute rounded-box z-[1] w-70 h-80 p-2 shadow overflow-y-auto overflow-x-hidden" data-autocomplete-target="results"></ul>
         </div>
@@ -43,7 +43,7 @@
       <div class="w-full px-3">
         <%= link_to t('reviews.form.select_product'), products_path, class: "btn btn-primary w-full mx-auto mb-2", data: { turbo_frame: "remote_modal" } %>
       </div>
-      <div class="w-full px-3">
+      <div class="w-full px-3 hidden" data-nested-form-target="recipe">
         <%= f.label "インクレシピ", class: "px-3" %>
         <template data-nested-form-target="template">
           <%= f.fields_for :ink_recipes, @review.ink_recipes, child_index: 'NEW_RECORD' do |ink_recipe_fields| %>

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -1,5 +1,5 @@
 <div data-controller="product">
-  <%= form_with(model: review, class: "w-full max-w-lg") do |f| %>
+  <%= form_with(model: review, data: { controller: 'nested-form', nested_form_wrapper_selector_value: '.nested-form-wrapper' }, class: "w-full max-w-lg") do |f| %>
     <%= render 'shared/error_messages', object: f.object %>
     <div class="flex flex-wrap -mx-3 mb-4">
       <div class="w-full px-3">
@@ -41,7 +41,21 @@
         </div>
       </div>
       <div class="w-full px-3">
-        <%= link_to t('reviews.form.select_product'), products_path, class: "btn btn-primary w-full mx-auto", data: { turbo_frame: "remote_modal" } %>
+        <%= link_to t('reviews.form.select_product'), products_path, class: "btn btn-primary w-full mx-auto mb-2", data: { turbo_frame: "remote_modal" } %>
+      </div>
+      <div class="w-full px-3">
+        <template data-nested-form-target="template">
+          <%= f.fields_for :ink_recipes, InkRecipe.new, child_index: 'NEW_RECORD' do |ink_recipe_fields| %>
+            <%= render "ink_recipes/recipe_form", f: ink_recipe_fields %>
+          <% end %>
+        </template>
+
+        <%= f.fields_for :ink_recipes do |ink_recipe_fields| %>
+          <%= render "ink_recipes/recipe_form", f: ink_recipe_fields %>
+        <% end %>
+        <%= f.label "インクレシピ", class: "px-3" %>
+        <div data-nested-form-target="target"></div>
+        <%= button_tag "インクレシピを追加する", data: { action: "nested-form#add" }, type: "button", class: "btn w-full mx-auto" %>
       </div>
     </div>
     <div class="flex flex-wrap -mx-3 mb-4">

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -44,7 +44,7 @@
         <%= link_to t('reviews.form.select_product'), products_path, class: "btn btn-primary w-full mx-auto mb-2", data: { turbo_frame: "remote_modal" } %>
       </div>
       <div class="w-full px-3 hidden" data-nested-form-target="recipe">
-        <%= f.label "インクレシピ", class: "px-3" %>
+        <%= f.label :ink_recipes, class: "px-3" %>
         <template data-nested-form-target="template">
           <%= f.fields_for :ink_recipes, @review.ink_recipes, child_index: 'NEW_RECORD' do |ink_recipe_fields| %>
             <%= render "ink_recipes/recipe_form", f: ink_recipe_fields %>
@@ -55,7 +55,7 @@
           <%= render "ink_recipes/recipe_form", f: ink_recipe_fields %>
         <% end %>
         <div data-nested-form-target="target"></div>
-        <%= button_tag "インクレシピを追加する", data: { action: "nested-form#add" }, type: "button", class: "btn btn-primary w-full mx-auto" %>
+        <%= button_tag t('reviews.form.add_ink_recipe'), data: { action: "nested-form#add" }, type: "button", class: "btn btn-primary w-full mx-auto" %>
       </div>
     </div>
     <div class="flex flex-wrap -mx-3 mb-4">

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -44,18 +44,18 @@
         <%= link_to t('reviews.form.select_product'), products_path, class: "btn btn-primary w-full mx-auto mb-2", data: { turbo_frame: "remote_modal" } %>
       </div>
       <div class="w-full px-3">
+        <%= f.label "インクレシピ", class: "px-3" %>
         <template data-nested-form-target="template">
-          <%= f.fields_for :ink_recipes, InkRecipe.new, child_index: 'NEW_RECORD' do |ink_recipe_fields| %>
+          <%= f.fields_for :ink_recipes, @review.ink_recipes, child_index: 'NEW_RECORD' do |ink_recipe_fields| %>
             <%= render "ink_recipes/recipe_form", f: ink_recipe_fields %>
           <% end %>
         </template>
 
-        <%= f.fields_for :ink_recipes do |ink_recipe_fields| %>
+        <%= f.fields_for :ink_recipes, @review.ink_recipes do |ink_recipe_fields| %>
           <%= render "ink_recipes/recipe_form", f: ink_recipe_fields %>
         <% end %>
-        <%= f.label "インクレシピ", class: "px-3" %>
         <div data-nested-form-target="target"></div>
-        <%= button_tag "インクレシピを追加する", data: { action: "nested-form#add" }, type: "button", class: "btn w-full mx-auto" %>
+        <%= button_tag "インクレシピを追加する", data: { action: "nested-form#add" }, type: "button", class: "btn btn-primary w-full mx-auto" %>
       </div>
     </div>
     <div class="flex flex-wrap -mx-3 mb-4">

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -54,6 +54,12 @@
           <% end %>
           <p><%= t('reviews.show.using_paper') %><%= @review.paper %></p>
           <p><%= t('reviews.show.using_pen') %><%= @review.pen %></p>
+          <% if @review.ink_recipes.present? %>
+            <p class="mt-2">インクレシピ</p>
+            <% @review.ink_recipes.each do |ink_recipe| %>
+              <p><%= ink_recipe.name %>：<%= ink_recipe.amount %>ml</p>
+            <% end %>
+          <% end %>
         </div>
         <% if current_user == @review.user %>
           <div class="flex items-center justify-center gap-4">

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -22,6 +22,7 @@ ja:
         body: 本文
         product_name: インク
         product: インク
+        ink_recipes: インクレシピ
         paper: 使用した紙
         pen: 使用したペン
         images: 画像

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -36,6 +36,9 @@ ja:
     post: 投稿する
     mypage: マイページ
     notification: 通知
+  footer:
+    contact: お問い合わせ
+    admin: 管理
   home:
     see_review: レビューを見る
     copywriting: |
@@ -59,6 +62,9 @@ ja:
     form:
       select_product: インクを選択
       number_of_images: 4枚まで投稿できます
+      add_ink_recipe: 入力フォームを追加する
+      ink_recipe_name: 使用したインク
+      ink_recipe_amount: 配合量
     index:
       title: レビュー一覧
       without_review: レビューがありません
@@ -70,6 +76,7 @@ ja:
     show:
       using_paper: 使った紙：
       using_pen: 使ったペン：
+      ink_recipes: インクレシピ
     edit:
       title: 投稿の編集
       notice: レビューを編集しました

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.13",
+    "@stimulus-components/rails-nested-form": "^5.0.0",
     "stimulus-autocomplete": "^3.1.0",
     "swiper": "^11.2.6",
     "tailwindcss-stimulus-components": "^6.1.3"

--- a/test/controllers/ink_recipes_controller_test.rb
+++ b/test/controllers/ink_recipes_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class InkRecipesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -225,6 +225,11 @@
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.2.201.tgz#bfb3da01b3e2462f5a18f372c52dedd7de76037f"
   integrity sha512-wsTdWoZ5EfG5k3t7ORdyQF0ZmDEgN4aVPCanHAiNEwCROqibSZMXXmCbH7IDJUVri4FOeAVwwbPINI7HVHPKBw==
 
+"@stimulus-components/rails-nested-form@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@stimulus-components/rails-nested-form/-/rails-nested-form-5.0.0.tgz#b443ad8ba5220328cfd704ca956ebf95ab8c4848"
+  integrity sha512-qrmmurT+KBPrz9iBlyrgJa6Di8i0j328kSk2SUR53nK5W0kDhw1YxVC91aUR+7EsFKiwJT1iB7oDSwpDhDQPeA==
+
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"


### PR DESCRIPTION
# 実施タスク
closes #115 
投稿フォームにインクレシピ入力欄を追加する。
オリジナルインクが選択されたときにインクレシピ入力欄を表示するようにする。

# 実施内容
- stimulus-components rails-nested-formをインストールしました。
- インクレシピ入力欄用のビューファイル（app/views/ink_recipes/_recipe_form.html.erb）を作成し、レビュー投稿フォームのビューファイル（app/views/reviews/_form.html.erb）にインクレシピ入力欄を表示・追加する記述を追加しました。
- app/javascript/controllers/nested_form_controller.jsをオーバーライドして、オリジナルインクが選択されたときにインクレシピ入力欄を表示するopenRecipeメソッドを追加しました。

# 備考
- アソシエーション名を間違えていたのも修正しています(ink_recipe → ink_recipes）。
- やり忘れてたところと一緒にi18n対応しました。
- インク選択モーダルからインクを選択→フォームに反映では、inputイベントもchangeイベントも発火しないので、`product#select`を実行する際に明示的にchangeイベントを発生させるようにしました。
changeなのでオートコンプリートから選択でもちゃんと`nested-form#openRecipe`が実行されます。