### PR TITLE
フォロー・フォロワー機能作成

### DIFF
--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -1,0 +1,13 @@
+class RelationshipsController < ApplicationController
+  before_action :redirect_root, only: [:create, :destroy]
+
+  def create
+    @user = User.find(params[:followed_id])
+    current_user.follow(@user)
+  end
+
+  def destroy
+    @user = Relationship.find(params[:id]).followed
+    current_user.unfollow(@user)
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,4 +9,18 @@ class UsersController < ApplicationController
     @bookmark_reviews = @user.bookmark_reviews.includes(:user).order(created_at: "DESC")
   end
 
+  def following
+    @title = "フォロー一覧"
+    @user = User.find_by(account: params[:id])
+    @users = @user.following
+    render 'show_follow'
+  end
+
+  def followers
+    @title = "フォロワー一覧"
+    @user = User.find_by(account: params[:id])
+    @users = @user.followers
+    render 'show_follow'
+  end
+
 end

--- a/app/helpers/relationships_helper.rb
+++ b/app/helpers/relationships_helper.rb
@@ -1,0 +1,2 @@
+module RelationshipsHelper
+end

--- a/app/javascript/controllers/remote_modal_controller.js
+++ b/app/javascript/controllers/remote_modal_controller.js
@@ -2,7 +2,14 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="remote-modal"
 export default class extends Controller {
+  static targets = ["frame"]
+
   connect() {
-    this.element.showModal()
+    this.element.showModal();
+  }
+
+  close() {
+    this.element.close();
+    this.element.remove();
   }
 }

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,0 +1,2 @@
+class Relationship < ApplicationRecord
+end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,2 +1,7 @@
 class Relationship < ApplicationRecord
+  belongs_to :follower, class_name: "User"
+  belongs_to :followed, class_name: "User"
+
+  validates :follower_id, presence: true
+  validates :followed_id, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,14 @@ class User < ApplicationRecord
   has_many :likes, dependent: :destroy
   has_many :bookmarks, dependent: :destroy
   has_many :bookmark_reviews, through: :bookmarks, source: :review
+  has_many :active_relationships, class_name: "Relationship",
+                                  foreign_key: "follower_id",
+                                  dependent: :destroy
+  has_many :passive_relationships, class_name:  "Relationship",
+                                   foreign_key: "followed_id",
+                                   dependent:   :destroy
+  has_many :following, through: :active_relationships, source: :followed
+  has_many :followers, through: :passive_relationships, source: :follower
   has_one_attached :avatar
 
   validates :name, presence: true, uniqueness: true, length: { maximum: 10 }
@@ -33,5 +41,17 @@ class User < ApplicationRecord
 
   def bookmarked_by?(review)
     bookmark_reviews.include?(review)
+  end
+
+  def follow(other_user)
+    following << other_user unless self == other_user
+  end
+
+  def unfollow(other_user)
+    following.delete(other_user)
+  end
+
+  def following?(other_user)
+    following.include?(other_user)
   end
 end

--- a/app/views/relationships/create.turbo_stream.erb
+++ b/app/views/relationships/create.turbo_stream.erb
@@ -1,0 +1,6 @@
+<%= turbo_stream.replace "follow-btn-for-user-#{@user.id}" do %>
+  <%= render 'users/unfollow', user: @user %>
+<% end %>
+<%= turbo_stream.replace "follow-count-#{@user.id}" do %>
+  <%= render 'users/stats', user: @user %>
+<% end %>

--- a/app/views/relationships/destroy.turbo_stream.erb
+++ b/app/views/relationships/destroy.turbo_stream.erb
@@ -1,0 +1,6 @@
+<%= turbo_stream.replace "unfollow-btn-for-user-#{@user.id}" do %>
+  <%= render 'users/follow', user: @user %>
+<% end %>
+<%= turbo_stream.replace "follow-count-#{@user.id}" do %>
+  <%= render 'users/stats', user: @user %>
+<% end %>

--- a/app/views/users/_follow.html.erb
+++ b/app/views/users/_follow.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "フォローする", relationships_path(followed_id: user.id), id: "follow-btn-for-user-#{user.id}", class: "btn btn-secondary w-[110px]", data: { turbo_method: :post } %>

--- a/app/views/users/_follow_form.html.erb
+++ b/app/views/users/_follow_form.html.erb
@@ -1,0 +1,7 @@
+<% if user_signed_in? %>
+  <% if current_user.following?(user) %>
+    <%= render "unfollow", user: user %>
+  <% else %>
+    <%= render "follow", user: user %>
+  <% end %>
+<% end %>

--- a/app/views/users/_profile_header.html.erb
+++ b/app/views/users/_profile_header.html.erb
@@ -13,12 +13,14 @@
     <div class="mt-5 mx-auto items-center justify-center hidden sm:block">
       <%= render 'x_share' %>
     </div>
+    <% unless current_user == @user %>
+      <div class="mt-2 mx-auto items-center justify-center hidden sm:block">
+        <%= render 'follow_form', user: @user %>
+      </div>
+    <% end %>
   </div>
   <div class="mx-10 flex flex-col">
     <span class="text-[36px] text-center"><%= @user.name %></span>
-    <!-- フォローフォロワー機能実装誤に使用
-    <div>0フォロー　0フォロワー</div>
-    -->
     <%= render 'stats' %>
     <p class="whitespace-pre-wrap"><%= @user.body %></p>
     <div class="flex items-center gap-4 mt-6">
@@ -41,5 +43,10 @@
     <div class="mt-5 mx-auto items-center justify-center sm:hidden">
       <%= render 'x_share' %>
     </div>
+    <% unless current_user == @user %>
+      <div class="mt-2 mx-auto items-center justify-center sm:hidden">
+        <%= render 'follow_form', user: @user %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/users/_profile_header.html.erb
+++ b/app/views/users/_profile_header.html.erb
@@ -19,6 +19,7 @@
     <!-- フォローフォロワー機能実装誤に使用
     <div>0フォロー　0フォロワー</div>
     -->
+    <%= render 'stats' %>
     <p class="whitespace-pre-wrap"><%= @user.body %></p>
     <div class="flex items-center gap-4 mt-6">
       <% if @user.x_account.present? %>

--- a/app/views/users/_stats.html.erb
+++ b/app/views/users/_stats.html.erb
@@ -1,0 +1,8 @@
+<div class="flex justify-center items-center gap-4 my-2">
+  <%= link_to following_user_path(@user), data: { turbo_frame: "remote_modal" } do %>
+    <%= @user.following.count %>フォロ－
+  <% end %>
+  <%= link_to followers_user_path(@user), data: { turbo_frame: "remote_modal" } do %>
+    <%= @user.followers.count %>フォロワー
+  <% end %>
+</div>

--- a/app/views/users/_stats.html.erb
+++ b/app/views/users/_stats.html.erb
@@ -1,4 +1,4 @@
-<div class="flex justify-center items-center gap-4 my-2">
+<div class="flex justify-center items-center gap-4 my-2" id="follow-count-<%= @user.id %>">
   <%= link_to following_user_path(@user), data: { turbo_frame: "remote_modal" } do %>
     <%= @user.following.count %>フォロ－
   <% end %>

--- a/app/views/users/_unfollow.html.erb
+++ b/app/views/users/_unfollow.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "フォロー中", relationship_path(current_user.active_relationships.find_by(followed_id: user.id)), id: "unfollow-btn-for-user-#{user.id}", class: "btn btn-accent w-[110px]", data: { turbo_method: :delete } %>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,0 +1,11 @@
+<div class="flex justify-between border-b-2 border-gray-100 sm:py-2 my-2 w-[280px] sm:w-[380px]">
+  <%= link_to  user_path(user), class: "flex items-center", id: user.id, data: { turbo_frame: "_top", action: "remote-modal#close" } do %>
+    <% if user.avatar.attached? %>
+      <%= image_tag user.avatar, class: "object-cover w-[44px] rounded-full mx-2 border-[2px] border-gray-200" %>
+    <% else %>
+      <%= image_tag 'kkrn_icon_user_1.png', class: "w-[44px] rounded-full mx-2 border-[2px] border-gray-200" %>
+    <% end %>
+    <p><%= user.name %></p>
+  <% end %>
+  <%= render 'follow_form', user: user %>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -12,4 +12,5 @@
       <% end %>
     </div>
   </div>
+  <%= turbo_frame_tag "remote_modal" %>
 </section>

--- a/app/views/users/show_follow.html.erb
+++ b/app/views/users/show_follow.html.erb
@@ -1,0 +1,9 @@
+<%= render "shared/remote_modal", title: @title do %>
+  <div class="container mx-auto w-full sm:px-10 py-5">
+    <div class="flex flex-col p-5 justify-center items-center">
+      <% if @users.present? %>
+        <%= render @users %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :relationships,       only: [:create, :destroy]
+  resources :relationships, only: [:create, :destroy]
 
   resources :products, only: %i[index show new create] do
     collection do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,13 @@ Rails.application.routes.draw do
   end
   resources :users, only: :show do
     resources :attachments, controller: "user/attachments", only: :destroy
-    get :bookmarks, on: :member
+    member do
+      get :bookmarks
+      get :following, :followers
+    end
   end
+
+  resources :relationships,       only: [:create, :destroy]
 
   resources :products, only: %i[index show new create] do
     collection do
@@ -47,6 +52,8 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   get '/users/:account', to: 'users#show'
   get '/users/:account/bookmarks', to: 'users#bookmarks'
+  get '/users/:account/following', to: 'users#following'
+  get '/users/:account/followers', to: 'users#followers'
   get '/contact/', to: 'static#contact'
   root "static#home"
 end

--- a/db/migrate/20250514045757_create_relationships.rb
+++ b/db/migrate/20250514045757_create_relationships.rb
@@ -1,0 +1,13 @@
+class CreateRelationships < ActiveRecord::Migration[7.2]
+  def change
+    create_table :relationships do |t|
+      t.integer :follower_id
+      t.integer :followed_id
+
+      t.timestamps
+    end
+    add_index :relationships, :follower_id
+    add_index :relationships, :followed_id
+    add_index :relationships, [:follower_id, :followed_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_07_111513) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_14_045757) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -89,6 +89,16 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_07_111513) do
     t.index ["brand_id"], name: "index_products_on_brand_id"
     t.index ["category_id"], name: "index_products_on_category_id"
     t.index ["name"], name: "index_products_on_name", unique: true
+  end
+
+  create_table "relationships", force: :cascade do |t|
+    t.integer "follower_id"
+    t.integer "followed_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["followed_id"], name: "index_relationships_on_followed_id"
+    t.index ["follower_id", "followed_id"], name: "index_relationships_on_follower_id_and_followed_id", unique: true
+    t.index ["follower_id"], name: "index_relationships_on_follower_id"
   end
 
   create_table "reviews", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -64,7 +64,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_14_045757) do
   create_table "ink_recipes", force: :cascade do |t|
     t.bigint "review_id", null: false
     t.string "name"
-    t.float "amount"
+    t.integer "amount"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["review_id"], name: "index_ink_recipes_on_review_id"

--- a/test/controllers/relationships_controller_test.rb
+++ b/test/controllers/relationships_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class RelationshipsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/relationships.yml
+++ b/test/fixtures/relationships.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  follower_id: 1
+  followed_id: 1
+
+two:
+  follower_id: 1
+  followed_id: 1

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class RelationshipTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 実施タスク 
closes #112 
フォロー・フォロワー機能の作成

# 実施内容
- [x] `docker compose exec web rails g model relationships follower_id:integer followed_id:integer`を実行する
- [x] マイグレーションファイルを編集する
- [x] `docker compose exec web rails db:migrate`を実行する
- [x] app/models/user.rbを編集してアソシエージョンとfollowingとfollowersの関連付けを定義
- [x] app/models/relationship.rbを編集してアソシエーションとバリデーションを定義
- [x] app/views/users/_stats.html.erbを作成・編集してフォロワーの統計情報を表示するビューを作成
- [x] app/views/users/_follow_form.html.erbを作成・編集してフォロー/フォロー解除用のビューを作成する
- [x] app/views/users/_follow.html.erbを作成・編集してフォロー用のフォームを作成する
- [x] app/views/users/_unfollow.html.erbを作成・編集してフォロー解除用のフォームを作成する
- [x] app/views/users/show.html.erbを編集してフォロワーの統計情報とフォロー/フォロー解除用のビューを表示する
- [x] app/controllers/users_controller.rbを編集してfollowingとfollowersのアクションを定義
- [x] app/views/users/show_follow.html.erbを作成・編集してフォロー/フォロワー一覧画面を作成
- [x] app/controllers/relationships_controller.rbを編集してcreateとdestroyアクションを定義
- [x] app/views/relationships/create.turbo_stream.erbを作成・編集する
- [x] app/views/relationships/destroy.turbo_stream.erbを作成・編集する
- [x] ルーティングを設定する

# 備考
- なぜか前回マージしたはずのdb/schema.rbの変更が反映されていないことになっていたのでコミットしてます（原因不明。GitHub上ではきちんと反映されており、ローカルでもdb/schema.rb以外の変更は反映されているのですが…）。
- フォロー・フォロワー一覧の`@users`変数及び_user.html.erbは紛らわしいので変数名変更するかもです。
- フォロー・フォロワー一覧モーダルから別のユーザーのプロフィールに移動→マイページに戻ると一瞬モーダルが表示されてすぐに消える現象が発生しました。`close()`関数を作成して別のユーザーのリンクをクリックすると同時にモーダルを閉じるようにしましたが、これではTurbo-flameのキャッシュで`data-controller="remote-modal"`が読み込まれてしまい、上記の減少が直らなかったので、`this.element.remove();`でモーダルのDOM事態を削除するようにしています。