### PR TITLE
fix: amountカラムの型がintegerになっていたのを修正

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -64,7 +64,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_14_045757) do
   create_table "ink_recipes", force: :cascade do |t|
     t.bigint "review_id", null: false
     t.string "name"
-    t.integer "amount"
+    t.float "amount"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["review_id"], name: "index_ink_recipes_on_review_id"


### PR DESCRIPTION
# 実施タスク
db/schema.rbのamountカラムの型がfloat→integerになっていたのを修正

# 実施内容
`docker compose exec web rails db:migrate`を実行したところ、db/schema.rbのamountカラムの型がfloatに戻りました。

# 備考
昨日の #196 時点でfloat→integerになっていましたが、integer→floatになっていたと勘違いしてコミットしてしまいました。
