### PR TITLE
レビュー投稿フォームの不具合修正

### DIFF
--- a/app/javascript/controllers/nested_form_controller.js
+++ b/app/javascript/controllers/nested_form_controller.js
@@ -4,6 +4,13 @@ export default class extends NestedForm {
   static targets = ["target", "template", "recipe", "name"]
   connect() {
     super.connect()
+    if (this.nameTarget.value.startsWith("オリジナル")) {
+      this.recipeTarget.classList.remove("hidden");
+    } else {
+      if (!this.recipeTarget.classList.contains("hidden")) {
+        this.recipeTarget.classList.add("hidden");
+      }
+    };
   }
 
   openRecipe() {

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -56,4 +56,3 @@
     </div>
   </div>
 </div>
-<%= turbo_frame_tag "remote_modal" %>

--- a/app/views/layouts/_mobile_header.html.erb
+++ b/app/views/layouts/_mobile_header.html.erb
@@ -103,4 +103,3 @@
     </div>
   </div>
 </div>
-<%= turbo_frame_tag "remote_modal" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,6 +31,7 @@
       <main class="flex-grow text-[#333333]">
         <%= render 'shared/flash_message' %>
         <%= yield %>
+        <%= turbo_frame_tag "remote_modal" %>
       </main>
       <footer class="footer bg-[#A6ABBD] text-[#424656] items-center p-4 sticky bottom-0 z-40 hidden sm:block">
         <%= render 'layouts/footer' %>

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -46,7 +46,7 @@
       <div class="w-full px-3 hidden" data-nested-form-target="recipe">
         <%= f.label :ink_recipes, class: "px-3" %>
         <template data-nested-form-target="template">
-          <%= f.fields_for :ink_recipes, @review.ink_recipes, child_index: 'NEW_RECORD' do |ink_recipe_fields| %>
+          <%= f.fields_for :ink_recipes, InkRecipe.new, child_index: 'NEW_RECORD' do |ink_recipe_fields| %>
             <%= render "ink_recipes/recipe_form", f: ink_recipe_fields %>
           <% end %>
         </template>


### PR DESCRIPTION
実施タスク
1. インク選択画面からインクを選択してもフォームに反映されない問題の修正
2. インクレシピを登録しているレビューの編集画面でインクレシピ入力欄が表示されない問題の修正
3. インクレシピを登録しているレビューの編集画面でインクレシピ入力欄を追加した際に、新規の入力欄ではなく既存のレシピが入力された入力欄が生成される問題の修正

# 実施内容
- インク選択画面からインクを選択してもフォームに反映されない問題を修正
- インクレシピを登録しているレビューの編集画面でインクレシピ入力欄が表示されない問題を修正
- インクレシピを登録しているレビューの編集画面でインクレシピ入力欄を追加した際に、新規の入力欄ではなく既存のレシピが入力された入力欄が生成される問題を修正

# 備考
- ①に関しては、通知画面モーダルようにヘッダーに仕込んだTurbo_frame_tagのほうでインク選択画面モーダルが開いていたため、`data-controller="product"`以下にモーダルのDOMが生成されなかったことが原因でした。同一IDの場合、先に見つかったTurbo_frame_tagが使用されるようなので、ヘッダーのTurbo_frame_tagをapplication.html.erbの`main`タグ下部に移動しています。不具合が起こるようならIDの変更を検討します。
- ②に関しては、インクレシピ入力欄を隠す`hidden`が編集画面を開いた際に消えるように、app/javascript/controllers/nested_form_controller.jsの`connect`にコード追加しました。
- ③に関しては、`template`内の`fields_for`を`InkRecipe.new`にすることで、新規の入力欄を追加できるようになりました。`@review.ink_recipes`にしていたため、登録されてるレシピが入力された入力欄が生成されていました。