### PR TITLE
ページネーション機能の追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,3 +78,5 @@ gem "administrate"
 gem "administrate-field-active_storage"
 
 gem "meta-tags"
+
+gem 'pagy', '~> 9.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,6 +238,7 @@ GEM
     nokogiri (1.18.4-x86_64-linux-musl)
       racc (~> 1.4)
     orm_adapter (0.5.0)
+    pagy (9.3.4)
     parallel (1.26.3)
     parser (3.3.7.1)
       ast (~> 2.4.1)
@@ -429,6 +430,7 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails
   meta-tags
+  pagy (~> 9.3)
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.2, >= 7.2.2.1)

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -40,3 +40,25 @@ dialog.slideover-search[open] {
     transform: translateY(-100%);
   }
 }
+
+.pagy {
+  @apply flex space-x-1 font-semibold text-sm text-gray-500;
+  a:not(.gap) {
+    @apply block rounded-lg px-3 py-1 bg-gray-200;
+    &:hover {
+      @apply bg-gray-300;
+    }
+    &:not([href]) { /* disabled links */
+      @apply text-gray-300 bg-gray-100 cursor-default;
+    }
+    &.current {
+      @apply text-white bg-gray-400;
+    }
+  }
+  label {
+    @apply inline-block whitespace-nowrap bg-gray-200 rounded-lg px-3 py-0.5;
+    input {
+      @apply bg-gray-100 border-none rounded-md;
+    }
+  }
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   # allow_browser versions: :modern
   before_action :configure_permitted_parameters, if: :devise_controller?
+  include Pagy::Backend
 
   protected
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -7,8 +7,8 @@ class ProductsController < ApplicationController
       @q = params[:q].split(/[\s　]/)
       @grouping_word = @q.each_with_index.reduce({}){|hash, (word, i)| hash.merge(i.to_s => { name_or_brand_name_cont: word })}
     end
-    @products = Product.ransack({ combinator: "and", groupings: @grouping_word }).
-                result(distinct: true).includes(:brand).order(created_at: "DESC")
+    @pagy, @products = pagy(Product.ransack({ combinator: "and", groupings: @grouping_word }).
+                            result(distinct: true).includes(:brand).order(created_at: "DESC"), limit: 10)
   end
 
   def show
@@ -53,8 +53,8 @@ class ProductsController < ApplicationController
     end
     @c = params[:c]
     @grouping_word["Category_refine"] = { category_id_eq: @c }
-    @products = Product.ransack({ combinator: "and", groupings: @grouping_word }).
-                result(distinct: true).includes(:brand).order(created_at: "DESC")
+    @pagy, @products = pagy(Product.ransack({ combinator: "and", groupings: @grouping_word }).
+                            result(distinct: true).includes(:brand).order(created_at: "DESC"), limit: 9)
   end
 
   def autocomplete

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -13,7 +13,7 @@ class ProductsController < ApplicationController
 
   def show
     @product = Product.find(params[:id])
-    @reviews = @product.reviews
+    @pagy, @reviews = pagy(@product.reviews, limit: 10)
   end
 
   def new

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -77,8 +77,8 @@ class ReviewsController < ApplicationController
     end
     @c = params[:c]
     @grouping_word["Category_refine"] = { product_category_id_eq: @c }
-    @reviews = Review.ransack({ combinator: "and", groupings: @grouping_word }).
-                result(distinct: true).includes(:user, product: :brand).order(created_at: "DESC")
+    @pagy, @reviews = pagy(Review.ransack({ combinator: "and", groupings: @grouping_word }).
+                            result(distinct: true).includes(:user, product: :brand).order(created_at: "DESC"), limit: 10)
   end
 
   private

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,6 +1,6 @@
 class StaticController < ApplicationController
   def home
-    @reviews = Review.includes(:user, :product).order(created_at: "DESC").all
+    @pagy, @reviews = pagy(Review.includes(:user, product: :brand).order(created_at: :desc), limit: 10)
     @category = Category.all
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,6 @@
 module ApplicationHelper
+  include Pagy::Frontend
+
   def default_meta_tags
     {
       site: 'iroGraphica',

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -4,7 +4,7 @@
     <h2 class="card-title"><%= product.name %></h2>
     <% if request.path.include?("search") %>
       <div class="card-actions justify-end">
-        <%= link_to t('product.index.show_product'), product_path(product), class: "btn btn-sm btn-primary" %>
+        <%= link_to t('product.index.show_product'), product_path(product), class: "btn btn-sm btn-primary", data: { turbo_frame: "_top" } %>
       </div>
     <% else %>
       <form method="dialog">

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -4,13 +4,15 @@
       <%= render 'search_form', url: products_path %>
     </div>
     <p><%= t('product.index.find_the_product') %></p><%= link_to t('product.new.title'), new_product_path, class: "link text-[#3F51B5]" %>
-    <div class="flex flex-wrap p-5 gap-5">
-      <% if @products.present? %>
-        <%= render @products %>
-      <% else %>
-        <p><%= t('product.index.without_product') %></p>
-      <% end %>
-    </div>
-    <%= render "shared/load_more_button" %>
+    <%= turbo_frame_tag "products" do %>
+      <div class="flex flex-wrap p-5 gap-5">
+        <% if @products.present? %>
+          <%= render @products %>
+        <% else %>
+          <p><%= t('product.index.without_product') %></p>
+        <% end %>
+      </div>
+      <%= render "shared/load_more_button" %>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -11,5 +11,6 @@
         <p><%= t('product.index.without_product') %></p>
       <% end %>
     </div>
+    <%= render "shared/load_more_button" %>
   </div>
 <% end %>

--- a/app/views/products/search.html.erb
+++ b/app/views/products/search.html.erb
@@ -7,4 +7,5 @@
       <div><%= t('reviews.index.without_review') %></div>
     <% end %>
   </div>
+  <%= render "shared/load_more_button" %>
 </div>

--- a/app/views/products/search.html.erb
+++ b/app/views/products/search.html.erb
@@ -1,11 +1,13 @@
 <div class="container mx-auto w-full px-10 py-5">
   <%= render 'shared/search_tab' %>
-  <div class="flex flex-wrap justify-center items-center p-5 gap-5">
-    <% if @products.present? %>
-      <%= render @products %>
-    <% else %>
-      <div><%= t('reviews.index.without_review') %></div>
-    <% end %>
-  </div>
-  <%= render "shared/load_more_button" %>
+  <%= turbo_frame_tag "search_products" do %>
+    <div class="flex flex-wrap justify-center items-center p-5 gap-5">
+      <% if @products.present? %>
+        <%= render @products %>
+      <% else %>
+        <div><%= t('reviews.index.without_review') %></div>
+      <% end %>
+    </div>
+    <%= render "shared/load_more_button" %>
+  <% end %>
 </div>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -15,12 +15,17 @@
         <% end %>
       </div>
     </div>
-    <div class="flex flex-wrap -m-4 justify-center items-center">
-      <% if @reviews.present? %>
-        <%= render partial: 'reviews/review', collection: @reviews %>
-      <% else %>
-        <div class="tracking-wider"><%= t('reviews.index.without_review') %></div>
-      <% end %>
-    </div>
+    <%= turbo_frame_tag "show_product_reviews" do %>
+      <div class="flex flex-col gap-4">
+        <div class="flex flex-wrap -m-4 justify-center items-center">
+          <% if @reviews.present? %>
+            <%= render partial: 'reviews/review', collection: @reviews %>
+          <% else %>
+            <div class="tracking-wider"><%= t('reviews.index.without_review') %></div>
+          <% end %>
+        </div>
+        <%= render "shared/load_more_button" %>
+      </div>
+    <% end %>
   </div>
 </section>

--- a/app/views/reviews/_review.html.erb
+++ b/app/views/reviews/_review.html.erb
@@ -34,7 +34,7 @@
     <div Class="overflow-hidden my-2 text-ellipsis line-clamp-3 whitespace-pre-wrap h-[72px]"><%= review.body %></div>
     <div class="text-xs text-[#959595]"><%= review.paper %>　<%= review.pen %></div>
     <div class="card-actions justify-end">
-      <%= link_to t('reviews.index.show_review'), review_path(review), class: "btn btn-sm btn-primary" %>
+      <%= link_to t('reviews.index.show_review'), review_path(review), class: "btn btn-sm btn-primary", data: { turbo_frame: "_top" } %>
     </div>
   </div>
 </div>

--- a/app/views/reviews/search.html.erb
+++ b/app/views/reviews/search.html.erb
@@ -1,11 +1,13 @@
 <div class="container mx-auto w-full px-10 py-5">
   <%= render 'shared/search_tab' %>
-  <div class="flex flex-wrap justify-center items-center p-5 gap-5">
-    <% if @reviews.present? %>
-      <%= render @reviews %>
-    <% else %>
-      <div><%= t('reviews.index.without_review') %></div>
-    <% end %>
-  </div>
-  <%= render "shared/load_more_button" %>
+  <%= turbo_frame_tag "search_reviews" do %>
+    <div class="flex flex-wrap justify-center items-center p-5 gap-5">
+      <% if @reviews.present? %>
+        <%= render @reviews %>
+      <% else %>
+        <div><%= t('reviews.index.without_review') %></div>
+      <% end %>
+    </div>
+    <%= render "shared/load_more_button" %>
+  <% end %>
 </div>

--- a/app/views/reviews/search.html.erb
+++ b/app/views/reviews/search.html.erb
@@ -7,4 +7,5 @@
       <div><%= t('reviews.index.without_review') %></div>
     <% end %>
   </div>
+  <%= render "shared/load_more_button" %>
 </div>

--- a/app/views/shared/_load_more_button.html.erb
+++ b/app/views/shared/_load_more_button.html.erb
@@ -1,0 +1,3 @@
+<div class="flex justify-center items-center">
+  <%== pagy_nav(@pagy) %>
+</div>

--- a/app/views/static/home.html.erb
+++ b/app/views/static/home.html.erb
@@ -12,12 +12,14 @@
     <% end %>
   </div>
   <h1 class="text-[32px] sm:text-5xl font-bold text-center mb-10 tracking-wider"><%= t('home.see_review') %></h1>
-  <div class="flex flex-wrap justify-center items-center p-5 gap-5">
-    <% if @reviews.present? %>
-      <%= render partial: 'reviews/review', collection: @reviews %>
-    <% else %>
-      <div class="tracking-wider"><%= t('reviews.index.without_review') %></div>
-    <% end %>
-  </div>
-  <%= render "shared/load_more_button" %>
+  <%= turbo_frame_tag "reviews" do %>
+    <div class="flex flex-wrap justify-center items-center p-5 gap-5">
+      <% if @reviews.present? %>
+        <%= render partial: 'reviews/review', collection: @reviews %>
+      <% else %>
+        <div class="tracking-wider"><%= t('reviews.index.without_review') %></div>
+      <% end %>
+    </div>
+    <%= render "shared/load_more_button" %>
+  <% end %>
 </div>

--- a/app/views/static/home.html.erb
+++ b/app/views/static/home.html.erb
@@ -19,4 +19,5 @@
       <div class="tracking-wider"><%= t('reviews.index.without_review') %></div>
     <% end %>
   </div>
+  <%= render "shared/load_more_button" %>
 </div>

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,220 @@
+# frozen_string_literal: true
+
+# Pagy initializer file (9.3.3)
+# Customize only what you really need and notice that the core Pagy works also without any of the following lines.
+# Should you just cherry pick part of this file, please maintain the require-order of the extras
+
+
+# Pagy Variables
+# See https://ddnexus.github.io/pagy/docs/api/pagy#variables
+# You can set any pagy variable as a Pagy::DEFAULT. They can also be overridden per instance by just passing them to
+# Pagy.new|Pagy::Countless.new|Pagy::Calendar::*.new or any of the #pagy* controller methods
+# Here are the few that make more sense as DEFAULTs:
+# Pagy::DEFAULT[:limit]       = 20                    # default
+# Pagy::DEFAULT[:size]        = 7                     # default
+# Pagy::DEFAULT[:ends]        = true                  # default
+# Pagy::DEFAULT[:page_param]  = :page                 # default
+# Pagy::DEFAULT[:count_args]  = []                    # example for non AR ORMs
+# Pagy::DEFAULT[:max_pages]   = 3000                  # example
+
+
+# Extras
+# See https://ddnexus.github.io/pagy/categories/extra
+
+
+# Legacy Compatibility Extras
+
+# Size extra: Enable the Array type for the `:size` variable (e.g. `size: [1,4,4,1]`)
+# See https://ddnexus.github.io/pagy/docs/extras/size
+# require 'pagy/extras/size'   # must be required before the other extras
+
+
+# Backend Extras
+
+# Arel extra: For better performance utilizing grouped ActiveRecord collections:
+# See: https://ddnexus.github.io/pagy/docs/extras/arel
+# require 'pagy/extras/arel'
+
+# Array extra: Paginate arrays efficiently, avoiding expensive array-wrapping and without overriding
+# See https://ddnexus.github.io/pagy/docs/extras/array
+# require 'pagy/extras/array'
+
+# Calendar extra: Add pagination filtering by calendar time unit (year, quarter, month, week, day)
+# See https://ddnexus.github.io/pagy/docs/extras/calendar
+# require 'pagy/extras/calendar'
+# Default for each calendar unit class in IRB:
+# >> Pagy::Calendar::Year::DEFAULT
+# >> Pagy::Calendar::Quarter::DEFAULT
+# >> Pagy::Calendar::Month::DEFAULT
+# >> Pagy::Calendar::Week::DEFAULT
+# >> Pagy::Calendar::Day::DEFAULT
+#
+# Uncomment the following lines, if you need calendar localization without using the I18n extra
+# module LocalizePagyCalendar
+#   def localize(time, opts)
+#     ::I18n.l(time, **opts)
+#   end
+# end
+# Pagy::Calendar.prepend LocalizePagyCalendar
+
+# Countless extra: Paginate without any count, saving one query per rendering
+# See https://ddnexus.github.io/pagy/docs/extras/countless
+# require 'pagy/extras/countless'
+# Pagy::DEFAULT[:countless_minimal] = false   # default (eager loading)
+
+# Elasticsearch Rails extra: Paginate `ElasticsearchRails::Results` objects
+# See https://ddnexus.github.io/pagy/docs/extras/elasticsearch_rails
+# Default :pagy_search method: change only if you use also
+# the searchkick or meilisearch extra that defines the same
+# Pagy::DEFAULT[:elasticsearch_rails_pagy_search] = :pagy_search
+# Default original :search method called internally to do the actual search
+# Pagy::DEFAULT[:elasticsearch_rails_search] = :search
+# require 'pagy/extras/elasticsearch_rails'
+
+# Headers extra: http response headers (and other helpers) useful for API pagination
+# See https://ddnexus.github.io/pagy/docs/extras/headers
+# require 'pagy/extras/headers'
+# Pagy::DEFAULT[:headers] = { page: 'Current-Page',
+#                            limit: 'Page-Items',
+#                            count: 'Total-Count',
+#                            pages: 'Total-Pages' }     # default
+
+# Keyset extra: Paginate with the Pagy keyset pagination technique
+# See https://ddnexus.github.io/pagy/docs/extras/keyset
+# require 'pagy/extras/keyset'
+
+# Meilisearch extra: Paginate `Meilisearch` result objects
+# See https://ddnexus.github.io/pagy/docs/extras/meilisearch
+# Default :pagy_search method: change only if you use also
+# the elasticsearch_rails or searchkick extra that define the same method
+# Pagy::DEFAULT[:meilisearch_pagy_search] = :pagy_search
+# Default original :search method called internally to do the actual search
+# Pagy::DEFAULT[:meilisearch_search] = :ms_search
+# require 'pagy/extras/meilisearch'
+
+# Metadata extra: Provides the pagination metadata to Javascript frameworks like Vue.js, react.js, etc.
+# See https://ddnexus.github.io/pagy/docs/extras/metadata
+# you must require the JS Tools internal extra (BEFORE the metadata extra) ONLY if you need also the :sequels
+# require 'pagy/extras/js_tools'
+# require 'pagy/extras/metadata'
+# For performance reasons, you should explicitly set ONLY the metadata you use in the frontend
+# Pagy::DEFAULT[:metadata] = %i[scaffold_url page prev next last]   # example
+
+# Searchkick extra: Paginate `Searchkick::Results` objects
+# See https://ddnexus.github.io/pagy/docs/extras/searchkick
+# Default :pagy_search method: change only if you use also
+# the elasticsearch_rails or meilisearch extra that defines the same
+# Pagy::DEFAULT[:searchkick_pagy_search] = :pagy_search
+# Default original :search method called internally to do the actual search
+# Pagy::DEFAULT[:searchkick_search] = :search
+# require 'pagy/extras/searchkick'
+# uncomment if you are going to use Searchkick.pagy_search
+# Searchkick.extend Pagy::Searchkick
+
+
+# Frontend Extras
+
+# Bootstrap extra: Add nav, nav_js and combo_nav_js helpers and templates for Bootstrap pagination
+# See https://ddnexus.github.io/pagy/docs/extras/bootstrap
+# require 'pagy/extras/bootstrap'
+
+# Bulma extra: Add nav, nav_js and combo_nav_js helpers and templates for Bulma pagination
+# See https://ddnexus.github.io/pagy/docs/extras/bulma
+# require 'pagy/extras/bulma'
+
+# Pagy extra: Add the pagy styled versions of the javascript-powered navs
+# and a few other components to the Pagy::Frontend module.
+# See https://ddnexus.github.io/pagy/docs/extras/pagy
+# require 'pagy/extras/pagy'
+
+# Multi size var used by the *_nav_js helpers
+# See https://ddnexus.github.io/pagy/docs/extras/pagy#steps
+# Pagy::DEFAULT[:steps] = { 0 => 5, 540 => 7, 720 => 9 }   # example
+
+
+# Feature Extras
+
+# Gearbox extra: Automatically change the limit per page depending on the page number
+# See https://ddnexus.github.io/pagy/docs/extras/gearbox
+# require 'pagy/extras/gearbox'
+# set to false only if you want to make :gearbox_extra an opt-in variable
+# Pagy::DEFAULT[:gearbox_extra] = false               # default true
+# Pagy::DEFAULT[:gearbox_limit] = [15, 30, 60, 100]   # default
+
+# Limit extra: Allow the client to request a custom limit per page with an optional selector UI
+# See https://ddnexus.github.io/pagy/docs/extras/limit
+# require 'pagy/extras/limit'
+# set to false only if you want to make :limit_extra an opt-in variable
+# Pagy::DEFAULT[:limit_extra] = false    # default true
+# Pagy::DEFAULT[:limit_param] = :limit   # default
+# Pagy::DEFAULT[:limit_max]   = 100      # default
+
+# Overflow extra: Allow for easy handling of overflowing pages
+# See https://ddnexus.github.io/pagy/docs/extras/overflow
+# require 'pagy/extras/overflow'
+# Pagy::DEFAULT[:overflow] = :empty_page    # default  (other options: :last_page and :exception)
+
+# Trim extra: Remove the page=1 param from links
+# See https://ddnexus.github.io/pagy/docs/extras/trim
+# require 'pagy/extras/trim'
+# set to false only if you want to make :trim_extra an opt-in variable
+# Pagy::DEFAULT[:trim_extra] = false # default true
+
+# Standalone extra: Use pagy in non Rack environment/gem
+# See https://ddnexus.github.io/pagy/docs/extras/standalone
+# require 'pagy/extras/standalone'
+# Pagy::DEFAULT[:url] = 'http://www.example.com/subdir'  # optional default
+
+# Jsonapi extra: Implements JSON:API specifications
+# See https://ddnexus.github.io/pagy/docs/extras/jsonapi
+# require 'pagy/extras/jsonapi'   # must be required after the other extras
+# set to false only if you want to make :jsonapi an opt-in variable
+# Pagy::DEFAULT[:jsonapi] = false  # default true
+
+# Rails
+# Enable the .js file required by the helpers that use javascript
+# (pagy*_nav_js, pagy*_combo_nav_js, and pagy_limit_selector_js)
+# See https://ddnexus.github.io/pagy/docs/api/javascript
+
+# With the asset pipeline
+# Sprockets need to look into the pagy javascripts dir, so add it to the assets paths
+# Rails.application.config.assets.paths << Pagy.root.join('javascripts')
+
+# I18n
+
+# Pagy internal I18n: ~18x faster using ~10x less memory than the i18n gem
+# See https://ddnexus.github.io/pagy/docs/api/i18n
+# Notice: No need to configure anything in this section if your app uses only "en"
+# or if you use the i18n extra below
+#
+# Examples:
+# load the "de" built-in locale:
+# Pagy::I18n.load(locale: 'de')
+#
+# load the "de" locale defined in the custom file at :filepath:
+# Pagy::I18n.load(locale: 'de', filepath: 'path/to/pagy-de.yml')
+#
+# load the "de", "en" and "es" built-in locales:
+# (the first passed :locale will be used also as the default_locale)
+# Pagy::I18n.load({ locale: 'de' },
+#                 { locale: 'en' },
+#                 { locale: 'es' })
+#
+# load the "en" built-in locale, a custom "es" locale,
+# and a totally custom locale complete with a custom :pluralize proc:
+# (the first passed :locale will be used also as the default_locale)
+# Pagy::I18n.load({ locale: 'en' },
+#                 { locale: 'es', filepath: 'path/to/pagy-es.yml' },
+#                 { locale: 'xyz',  # not built-in
+#                   filepath: 'path/to/pagy-xyz.yml',
+#                   pluralize: lambda{ |count| ... } )
+
+
+# I18n extra: uses the standard i18n gem which is ~18x slower using ~10x more memory
+# than the default pagy internal i18n (see above)
+# See https://ddnexus.github.io/pagy/docs/extras/i18n
+# require 'pagy/extras/i18n'
+
+
+# When you are done setting your own default freeze it, so it will not get changed accidentally
+Pagy::DEFAULT.freeze

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -125,7 +125,7 @@ require 'pagy/extras/countless'
 # Pagy extra: Add the pagy styled versions of the javascript-powered navs
 # and a few other components to the Pagy::Frontend module.
 # See https://ddnexus.github.io/pagy/docs/extras/pagy
-# require 'pagy/extras/pagy'
+require 'pagy/extras/pagy'
 
 # Multi size var used by the *_nav_js helpers
 # See https://ddnexus.github.io/pagy/docs/extras/pagy#steps

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -59,7 +59,7 @@
 
 # Countless extra: Paginate without any count, saving one query per rendering
 # See https://ddnexus.github.io/pagy/docs/extras/countless
-# require 'pagy/extras/countless'
+require 'pagy/extras/countless'
 # Pagy::DEFAULT[:countless_minimal] = false   # default (eager loading)
 
 # Elasticsearch Rails extra: Paginate `ElasticsearchRails::Results` objects

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -59,7 +59,7 @@
 
 # Countless extra: Paginate without any count, saving one query per rendering
 # See https://ddnexus.github.io/pagy/docs/extras/countless
-require 'pagy/extras/countless'
+# require 'pagy/extras/countless'
 # Pagy::DEFAULT[:countless_minimal] = false   # default (eager loading)
 
 # Elasticsearch Rails extra: Paginate `ElasticsearchRails::Results` objects

--- a/config/initializers/pagy.rb:Zone.Identifier
+++ b/config/initializers/pagy.rb:Zone.Identifier
@@ -1,0 +1,4 @@
+[ZoneTransfer]
+ZoneId=3
+ReferrerUrl=https://ddnexus.github.io/pagy/quick-start/
+HostUrl=https://ddnexus.github.io/pagy/gem/config/pagy.rb


### PR DESCRIPTION
# 実施タスク
closes #41 
ページネーションのgemを追加してhome、productのindex、search、show、reviewのsearchにページネーション実装

# 実施内容
`gem 'pagy'`を追加してページネーションを実装しました。

# 備考
ページネーションのgemは当初kaminariで考えていましたが、pagyのほうがメモリ消費が少なく高速とのことでpagyを使用することにしました。
[Rails: Pagy gemでRailsアプリを高速ページネーション（翻訳）](https://techracho.bpsinc.jp/hachi8833/2021_07_13/57481)

また、無限スクロールでの実装も考えましたが、①ページロードが増加する、②コンテンツを再度見つけようとすると再スクロールが必要になる、等iroGraphicaには向いてない要素があるためやめました。