### PR TITLE
ローディングアニメーションの実装

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -1,7 +1,9 @@
 class ReviewsController < ApplicationController
   before_action :redirect_root, only: :new
 
-  def index; end
+  def index
+    @pagy, @reviews = pagy(Review.includes(:user, product: :brand).order(created_at: :desc), limit: 10)
+  end
 
   def new
     @review = Review.new

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,6 +1,5 @@
 class StaticController < ApplicationController
   def home
-    @pagy, @reviews = pagy(Review.includes(:user, product: :brand).order(created_at: :desc), limit: 10)
     @category = Category.all
   end
 

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -10,6 +10,9 @@ application.register("flash", FlashController)
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 
+import LoadingController from "./loading_controller"
+application.register("loading", LoadingController)
+
 import NestedFormController from "./nested_form_controller"
 application.register("nested-form", NestedFormController)
 

--- a/app/javascript/controllers/loading_controller.js
+++ b/app/javascript/controllers/loading_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="loading"
+export default class extends Controller {
+  static targets = ["load"]
+
+  connect() {
+    this.hide()
+  }
+
+  show() {
+    this.loadTarget.classList.remove("hidden")
+  }
+
+  hide() {
+    this.loadTarget.classList.add("hidden")
+  }
+}

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,86 +1,89 @@
-<div class="container mx-auto w-full sm:w-[540px] px-10 py-5">
-  <h1 class="text-[24px] sm:text-5xl font-bold text-center mb-10"><%= t('users.edit.title') %></h1>
+<div data-controller="loading">
+  <%= render "shared/loading" %>
+  <div class="container mx-auto w-full sm:w-[540px] px-10 py-5">
+    <h1 class="text-[24px] sm:text-5xl font-bold text-center mb-10"><%= t('users.edit.title') %></h1>
 
-  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-    <%= render "devise/shared/error_messages", resource: resource %>
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
 
-    <div class="field">
-      <%= f.label :account %><br />
-      <%= f.text_field :account, autofocus: true, autocomplete: "account", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: t('devise.registrations.new.account_validate') %>
-    </div>
-    <div class="field">
-      <%= f.label :name %><br />
-      <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: t('devise.registrations.new.maximum_name_length') %>
-    </div>
-    <div class="field">
-      <%= f.label :body %><br />
-      <%= f.text_area :body, autofocus: true, autocomplete: "body", class: "textarea textarea-bordered textarea-lg resize-none form-control h-[200px] w-full mx-auto pl-2 pt-1 text-base mb-6", placeholder: t('users.edit.body_length') %>
-    </div>
-    <div class="field">
-      <%= f.label :avatar %><br />
-      <%= f.file_field :avatar, accept: "image/jpeg,image/png", class: "file-input file-input-bordered form-control mb-6 w-full mx-auto mt-2" %>
-      <% if @user.avatar.attached? %>
-        <div class="flex flex-col items-center justify-center">
-          <%= image_tag @user.avatar, class: "w-12 rounded-full", avatar: @user.reload.avatar %>
-          <%=link_to user_attachment_path(@user.id, @user.avatar.id), data: { turbo_method: :delete } do %>
-            <i class="fa-regular fa-circle-xmark"></i>
-          <% end %>
-        </div>
+      <div class="field">
+        <%= f.label :account %><br />
+        <%= f.text_field :account, autofocus: true, autocomplete: "account", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: t('devise.registrations.new.account_validate') %>
+      </div>
+      <div class="field">
+        <%= f.label :name %><br />
+        <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: t('devise.registrations.new.maximum_name_length') %>
+      </div>
+      <div class="field">
+        <%= f.label :body %><br />
+        <%= f.text_area :body, autofocus: true, autocomplete: "body", class: "textarea textarea-bordered textarea-lg resize-none form-control h-[200px] w-full mx-auto pl-2 pt-1 text-base mb-6", placeholder: t('users.edit.body_length') %>
+      </div>
+      <div class="field">
+        <%= f.label :avatar %><br />
+        <%= f.file_field :avatar, accept: "image/jpeg,image/png", class: "file-input file-input-bordered form-control mb-6 w-full mx-auto mt-2" %>
+        <% if @user.avatar.attached? %>
+          <div class="flex flex-col items-center justify-center">
+            <%= image_tag @user.avatar, class: "w-12 rounded-full", avatar: @user.reload.avatar %>
+            <%=link_to user_attachment_path(@user.id, @user.avatar.id), data: { turbo_method: :delete } do %>
+              <i class="fa-regular fa-circle-xmark"></i>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+      <div class="field">
+        <%= f.label :x_account %><br />
+        <%= f.text_field :x_account, autofocus: true, autocomplete: "name", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: t('users.edit.x_account_url') %>
+      </div>
+      <div class="field">
+        <%= f.label :instagram_account %><br />
+        <%= f.text_field :instagram_account, autofocus: true, autocomplete: "name", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: t('users.edit.instagram_account_url') %>
+      </div>
+      <div class="field">
+        <%= f.label :youtube_account %><br />
+        <%= f.text_field :youtube_account, autofocus: true, autocomplete: "name", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: t('users.edit.youtube_account_url') %>
+      </div>
+
+      <!-- パスワードとメールアドレスの変更。別ページ作成
+      <div class="field">
+        <%= f.label :email %><br />
+        <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+      </div>
+
+      <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+        <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
       <% end %>
-    </div>
-    <div class="field">
-      <%= f.label :x_account %><br />
-      <%= f.text_field :x_account, autofocus: true, autocomplete: "name", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: t('users.edit.x_account_url') %>
-    </div>
-    <div class="field">
-      <%= f.label :instagram_account %><br />
-      <%= f.text_field :instagram_account, autofocus: true, autocomplete: "name", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: t('users.edit.instagram_account_url') %>
-    </div>
-    <div class="field">
-      <%= f.label :youtube_account %><br />
-      <%= f.text_field :youtube_account, autofocus: true, autocomplete: "name", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: t('users.edit.youtube_account_url') %>
-    </div>
 
-    <!-- パスワードとメールアドレスの変更。別ページ作成
-    <div class="field">
-      <%= f.label :email %><br />
-      <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-    </div>
+      <div class="field">
+        <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+        <%= f.password_field :password, autocomplete: "new-password" %>
+        <% if @minimum_password_length %>
+          <br />
+          <em><%= @minimum_password_length %> characters minimum</em>
+        <% end %>
+      </div>
 
-    <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-      <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+      <div class="field">
+        <%= f.label :password_confirmation %><br />
+        <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+      </div>
+
+      <div class="field">
+        <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+        <%= f.password_field :current_password, autocomplete: "current-password" %>
+      </div>
+      -->
+      <div class="actions">
+        <%= f.submit nil, class: "btn btn-secondary mb-6 w-full mx-auto mt-2", data: { action: "click->loading#show" } %>
+      </div>
     <% end %>
 
-    <div class="field">
-      <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-      <%= f.password_field :password, autocomplete: "new-password" %>
-      <% if @minimum_password_length %>
-        <br />
-        <em><%= @minimum_password_length %> characters minimum</em>
-      <% end %>
-    </div>
+    <!-- アカウント削除。別ページで使用
+    <h3>Cancel my account</h3>
 
-    <div class="field">
-      <%= f.label :password_confirmation %><br />
-      <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-    </div>
-
-    <div class="field">
-      <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-      <%= f.password_field :current_password, autocomplete: "current-password" %>
-    </div>
+    <div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
     -->
-    <div class="actions">
-      <%= f.submit nil, class: "btn btn-secondary mb-6 w-full mx-auto mt-2" %>
+    <div class="flex items-center justify-center">
+      <%= link_to t('helpers.links.back'), 'javascript:history.back()', class: "btn btn-outline btn-primary" %>
     </div>
-  <% end %>
-
-  <!-- アカウント削除。別ページで使用
-  <h3>Cancel my account</h3>
-
-  <div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
-  -->
-  <div class="flex items-center justify-center">
-    <%= link_to t('helpers.links.back'), 'javascript:history.back()', class: "btn btn-outline btn-primary" %>
   </div>
 </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,38 +1,40 @@
+<div data-controller="loading">
+  <%= render "shared/loading" %>
+  <div class="container mx-auto w-full sm:w-[540px] px-10 py-5">
+    <h1 class="text-[24px] sm:text-5xl font-bold text-center mb-10"><%= t('devise.registrations.new.title') %></h1>
 
-<div class="container mx-auto w-full sm:w-[540px] px-10 py-5">
-  <h1 class="text-[24px] sm:text-5xl font-bold text-center mb-10"><%= t('devise.registrations.new.title') %></h1>
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
+      <div class="field">
+        <%= f.label :account %><br />
+        <%= f.text_field :account, autofocus: true, autocomplete: "account", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: t('devise.registrations.new.account_validate') %>
+      </div>
+      <div class="field">
+        <%= f.label :name %><br />
+        <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: t('devise.registrations.new.maximum_name_length') %>
+      </div>
+      <div class="field">
+        <%= f.label :email %><br />
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: t('devise.registrations.new.input_email') %>
+      </div>
 
-  <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-    <%= render "devise/shared/error_messages", resource: resource %>
-    <div class="field">
-      <%= f.label :account %><br />
-      <%= f.text_field :account, autofocus: true, autocomplete: "account", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: t('devise.registrations.new.account_validate') %>
-    </div>
-    <div class="field">
-      <%= f.label :name %><br />
-      <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: t('devise.registrations.new.maximum_name_length') %>
-    </div>
-    <div class="field">
-      <%= f.label :email %><br />
-      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: t('devise.registrations.new.input_email') %>
-    </div>
+      <div class="field">
+        <%= f.label :password %><br />
+        <%= f.password_field :password, autocomplete: "new-password", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: t('devise.registrations.new.minimum_password_length', password_length: @minimum_password_length) %>
+      </div>
 
-    <div class="field">
-      <%= f.label :password %><br />
-      <%= f.password_field :password, autocomplete: "new-password", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: t('devise.registrations.new.minimum_password_length', password_length: @minimum_password_length) %>
-    </div>
+      <div class="field">
+        <%= f.label :password_confirmation %><br />
+        <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: t('devise.registrations.new.re_input_password') %>
+      </div>
 
-    <div class="field">
-      <%= f.label :password_confirmation %><br />
-      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: t('devise.registrations.new.re_input_password') %>
-    </div>
+      <div class="actions">
+        <%= f.submit t('devise.registrations.new.create'), class: "btn btn-secondary mb-6 w-full mx-auto mt-2", data: { action: "click->loading#show" } %>
+      </div>
+    <% end %>
 
-    <div class="actions">
-      <%= f.submit t('devise.registrations.new.create'), class: "btn btn-secondary mb-6 w-full mx-auto mt-2" %>
+    <div class="text-center">
+      <%= render "devise/shared/links" %>
     </div>
-  <% end %>
-
-  <div class="text-center">
-    <%= render "devise/shared/links" %>
   </div>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,30 +1,33 @@
-<div class="container mx-auto w-full sm:w-[540px] px-10 py-5">
-  <h1 class="text-[24px] sm:text-5xl font-bold text-center mb-10"><%= t('devise.sessions.new.title') %></h1>
+<div data-controller="loading">
+  <%= render "shared/loading" %>
+  <div class="container mx-auto w-full sm:w-[540px] px-10 py-5">
+    <h1 class="text-[24px] sm:text-5xl font-bold text-center mb-10"><%= t('devise.sessions.new.title') %></h1>
 
-  <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-    <div class="field">
-      <%= f.label :email %><br />
-      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2" %>
-    </div>
-
-    <div class="field">
-      <%= f.label :password %><br />
-      <%= f.password_field :password, autocomplete: "current-password", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2" %>
-    </div>
-
-    <% if devise_mapping.rememberable? %>
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
       <div class="field">
-        <%= f.check_box :remember_me, class:"checkbox" %>
-        <%= f.label :remember_me %>
+        <%= f.label :email %><br />
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2" %>
+      </div>
+
+      <div class="field">
+        <%= f.label :password %><br />
+        <%= f.password_field :password, autocomplete: "current-password", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2" %>
+      </div>
+
+      <% if devise_mapping.rememberable? %>
+        <div class="field">
+          <%= f.check_box :remember_me, class:"checkbox" %>
+          <%= f.label :remember_me %>
+        </div>
+      <% end %>
+
+      <div class="actions">
+        <%= f.submit t('devise.sessions.new.sign_in'), class: "btn btn-secondary mb-6 w-full mx-auto mt-2", data: { action: "click->loading#show" } %>
       </div>
     <% end %>
 
-    <div class="actions">
-      <%= f.submit t('devise.sessions.new.sign_in'), class: "btn btn-secondary mb-6 w-full mx-auto mt-2" %>
+    <div class="text-center">
+        <%= render "devise/shared/links" %>
     </div>
-  <% end %>
-
-  <div class="text-center">
-      <%= render "devise/shared/links" %>
   </div>
 </div>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -15,17 +15,23 @@
         <% end %>
       </div>
     </div>
-    <%= turbo_frame_tag "show_product_reviews" do %>
-      <div class="flex flex-col gap-4">
-        <div class="flex flex-wrap -m-4 justify-center items-center">
-          <% if @reviews.present? %>
-            <%= render partial: 'reviews/review', collection: @reviews %>
-          <% else %>
-            <div class="tracking-wider"><%= t('reviews.index.without_review') %></div>
-          <% end %>
+    <% if turbo_frame_request? %>
+      <%= turbo_frame_tag "show_product_reviews" do %>
+        <div class="flex flex-col gap-4">
+          <div class="flex flex-wrap -m-4 justify-center items-center">
+            <% if @reviews.present? %>
+              <%= render partial: 'reviews/review', collection: @reviews %>
+            <% else %>
+              <div class="tracking-wider"><%= t('reviews.index.without_review') %></div>
+            <% end %>
+          </div>
+          <%= render "shared/load_more_button" %>
         </div>
-        <%= render "shared/load_more_button" %>
-      </div>
+      <% end %>
+    <% else %>
+      <%= turbo_frame_tag "show_product_reviews", src: product_path(@product) do %>
+        <%= render "shared/skeleton_card" %>
+      <% end %>
     <% end %>
   </div>
 </section>

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -1,4 +1,5 @@
-<div data-controller="product">
+<div data-controller="product loading">
+  <%= render "shared/loading" %>
   <%= form_with(model: review, data: { controller: 'nested-form', nested_form_wrapper_selector_value: '.nested-form-wrapper' }, class: "w-full max-w-lg") do |f| %>
     <%= render 'shared/error_messages', object: f.object %>
     <div class="flex flex-wrap -mx-3 mb-4">
@@ -68,7 +69,7 @@
         <%= f.text_field :pen, class: "input input-bordered form-control mb-6 w-full mx-auto pl-2 text-base" %>
       </div>
     </div>
-    <%= f.submit nil, class: "btn btn-secondary w-full mx-auto mt-2" %>
+    <%= f.submit nil, class: "btn btn-secondary w-full mx-auto mt-2", data: { action: "click->loading#show" } %>
   <% end %>
   <%= turbo_frame_tag "remote_modal" %>
 </div>

--- a/app/views/reviews/_show_skeleton.html.erb
+++ b/app/views/reviews/_show_skeleton.html.erb
@@ -1,0 +1,40 @@
+<div class="container px-5 py-10 mx-auto">
+  <div class="lg:w-4/5 mx-auto flex flex-wrap items-center justify-center">
+    <div class="flex flex-col lg:w-1/2 items-center justify-center">
+        <div class="skeleton w-[300px] sm:w-[350px] h-[300px] sm:h-[350px]"></div>
+        <div class="flex w-[300px] sm:w-[350px] mt-1 gap-3">
+          <div class="skeleton w-[60px] sm:w-[80px] h-[60px] sm:h-[80px]"></div>
+          <div class="skeleton w-[60px] sm:w-[80px] h-[60px] sm:h-[80px]"></div>
+          <div class="skeleton w-[60px] sm:w-[80px] h-[60px] sm:h-[80px]"></div>
+          <div class="skeleton w-[60px] sm:w-[80px] h-[60px] sm:h-[80px]"></div>
+        </div>
+      <div class="mt-5 mx-auto">
+        <div class="skeleton h-[48px] w-[300px] sm:w-[350px]"></div>
+      </div>
+    </div>
+    <div class="lg:w-1/2 w-full lg:pl-10 lg:py-6 mt-6 lg:mt-0">
+      <div class="skeleton h-[36px] w-full mb-1"></div>
+      <div class="flex">
+        <div class="skeleton h-10 w-10 shrink-0 rounded-full"></div>
+        <div class="flex ml-auto items-center justify-center">
+          <div class="skeleton h-4 w-20"></div>
+        </div>
+      </div>
+      <div class="flex mb-4 mt-1 gap-2">
+        <div class="skeleton h-[36px] w-20"></div>
+      </div>
+        <div class="flex flex-col gap-2">
+        <div class="skeleton h-4 w-full"></div>
+        <div class="skeleton h-4 w-full"></div>
+        <div class="skeleton h-4 w-full"></div>
+        <div class="skeleton h-4 w-full"></div>
+        <div class="skeleton h-4 w-full"></div>
+      </div>
+      <div class="flex flex-col gap-2 justify-start mt-6 pb-5 border-t-2 border-gray-100 mb-5">
+        <div class="skeleton h-4 w-28"></div>
+        <div class="skeleton h-4 w-28"></div>
+        <div class="skeleton h-4 w-28"></div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/reviews/index.html.erb
+++ b/app/views/reviews/index.html.erb
@@ -1,5 +1,4 @@
-<div class="container mx-auto w-full px-10 py-5">
-  <h1 class="text-5xl font-bold text-center mb-10"><%= t('reviews.index.title') %></h1>
+<%= turbo_frame_tag "reviews" do %>
   <div class="flex flex-wrap justify-center items-center p-5 gap-5">
     <% if @reviews.present? %>
       <%= render @reviews %>
@@ -7,4 +6,5 @@
       <div><%= t('reviews.index.without_review') %></div>
     <% end %>
   </div>
-</div>
+  <%= render "shared/load_more_button" %>
+<% end %>

--- a/app/views/reviews/search.html.erb
+++ b/app/views/reviews/search.html.erb
@@ -1,13 +1,19 @@
 <div class="container mx-auto w-full px-10 py-5">
   <%= render 'shared/search_tab' %>
-  <%= turbo_frame_tag "search_reviews" do %>
-    <div class="flex flex-wrap justify-center items-center p-5 gap-5">
-      <% if @reviews.present? %>
-        <%= render @reviews %>
-      <% else %>
-        <div><%= t('reviews.index.without_review') %></div>
-      <% end %>
-    </div>
-    <%= render "shared/load_more_button" %>
+  <% if turbo_frame_request? %>
+    <%= turbo_frame_tag "search_reviews" do %>
+      <div class="flex flex-wrap justify-center items-center p-5 gap-5">
+        <% if @reviews.present? %>
+          <%= render @reviews %>
+        <% else %>
+          <div><%= t('reviews.index.without_review') %></div>
+        <% end %>
+      </div>
+      <%= render "shared/load_more_button" %>
+    <% end %>
+  <% else %>
+    <%= turbo_frame_tag "search_reviews", src: search_reviews_path do %>
+      <%= render "shared/skeleton_card" %>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -1,97 +1,105 @@
-<section class="overflow-hidden">
-  <div class="container px-5 py-10 mx-auto">
-    <div class="lg:w-4/5 mx-auto flex flex-wrap items-center justify-center">
-      <div class="flex flex-col lg:w-1/2 items-center justify-center">
-        <% if @review.images.present? %>
-          <div style="--swiper-navigation-color: #fff; --swiper-pagination-color: #fff" class="swiper mySwiper2 w-[300px] sm:w-[350px] h-[300px] sm:h-[350px]">
-            <div class="swiper-wrapper">
-              <% @review.images.each do |image| %>
-                <%= image_tag image, class: "w-[300px] sm:w-[350px] h-[300px] sm:h-[350px] object-cover object-center rounded swiper-slide mr-[30px]" %>
-              <% end %>
-            </div>
-            <div class="swiper-button-next"></div>
-            <div class="swiper-button-prev"></div>
-          </div>
-          <div thumbsSlider="" class="swiper mySwiper w-[300px] sm:w-[350px] mt-1">
-            <div class="swiper-wrapper">
-              <% @review.images.each do |image| %>
-                <%= image_tag image, class: "w-[60px] sm:w-[80px] h-[60px] sm:h-[80px] object-fill object-center rounded swiper-slide" %>
-              <% end %>
-            </div>
-          </div>
-        <% else %>
-          <div>
-            <%= image_tag "kkrn_icon_shashin_3.png", class: "w-[300px] sm:w-[350px] h-[300px] sm:h-[350px] object-cover object-center rounded mx-auto" %>
-          </div>
-        <% end %>
-        <div class="mt-5 mx-auto">
-          <%= link_to "https://twitter.com/share?url=#{post_review_url(@review)}&text=【#{@review.title}】%0a#{@review.product.brand.name}%20#{@review.product.name}のレビューをシェア%0a%0a%23インク沼%20%23iroGraphica%0a", title: "Xでシェア", class: "btn btn-neutral gap-0 w-[300px] sm:w-[350px]", target: :_blank, rel: "noopener noreferrer nofollow" do %>
-            <i class="fa-brands fa-x-twitter text-[24px]"></i></i><span class="text-[20px]">でシェア</span>
-          <% end %>
-        </div>
-      </div>
-      <div class="lg:w-1/2 w-full lg:pl-10 lg:py-6 mt-6 lg:mt-0">
-        <h1 class="text-gray-900 text-3xl title-font font-medium mb-1"><%= @review.title %></h1>
-        <div class="flex">
-          <%= link_to user_path(@review.user), class: "flex items-center gap-2" do %>
-            <% if @review.user.avatar.attached? %>
-              <%= image_tag @review.user.avatar, class: "w-10 rounded-full border-[2px] border-gray-200" %>
+<% if turbo_frame_request? %>
+  <%= turbo_frame_tag "show_review" do %>
+    <section class="overflow-hidden">
+      <div class="container px-5 py-10 mx-auto">
+        <div class="lg:w-4/5 mx-auto flex flex-wrap items-center justify-center">
+          <div class="flex flex-col lg:w-1/2 items-center justify-center">
+            <% if @review.images.present? %>
+              <div style="--swiper-navigation-color: #fff; --swiper-pagination-color: #fff" class="swiper mySwiper2 w-[300px] sm:w-[350px] h-[300px] sm:h-[350px]">
+                <div class="swiper-wrapper">
+                  <% @review.images.each do |image| %>
+                    <%= image_tag image, class: "w-[300px] sm:w-[350px] h-[300px] sm:h-[350px] object-cover object-center rounded swiper-slide mr-[30px]" %>
+                  <% end %>
+                </div>
+                <div class="swiper-button-next"></div>
+                <div class="swiper-button-prev"></div>
+              </div>
+              <div thumbsSlider="" class="swiper mySwiper w-[300px] sm:w-[350px] mt-1">
+                <div class="swiper-wrapper">
+                  <% @review.images.each do |image| %>
+                    <%= image_tag image, class: "w-[60px] sm:w-[80px] h-[60px] sm:h-[80px] object-fill object-center rounded swiper-slide" %>
+                  <% end %>
+                </div>
+              </div>
             <% else %>
-              <%= image_tag 'kkrn_icon_user_1.png', class: "w-10 rounded-full border-[2px] border-gray-200" %>
+              <div>
+                <%= image_tag "kkrn_icon_shashin_3.png", class: "w-[300px] sm:w-[350px] h-[300px] sm:h-[350px] object-cover object-center rounded mx-auto" %>
+              </div>
             <% end %>
-            <p><%= @review.user.name %></p>
-          <% end %>
-          <div class="flex ml-auto items-center justify-center text-[#959595]"><%= l(@review.created_at) %></div>
-        </div>
-        <div class="flex mb-4 mx-3 gap-2">
-          <%= render "reviews/like_btn", review: @review %>
-          <%= render "reviews/bookmark_btn", review: @review %>
-        </div>
-        <p class="leading-relaxed whitespace-pre-wrap"><%= @review.body %></p>
-        <div class="mt-6 items-center pb-5 border-t-2 border-gray-100 mb-5">
-          <%= link_to product_path(@review.product.id), class: "link text-[#3F51B5]" do %>
-            <p><%= @review.product.brand.name %><%= @review.product.name %></p>
-          <% end %>
-          <p><%= t('reviews.show.using_paper') %><%= @review.paper %></p>
-          <p><%= t('reviews.show.using_pen') %><%= @review.pen %></p>
-          <% if @review.ink_recipes.present? %>
-            <p class="mt-2">インクレシピ</p>
-            <% @review.ink_recipes.each do |ink_recipe| %>
-              <p><%= ink_recipe.name %>：<%= ink_recipe.amount %>ml</p>
-            <% end %>
-          <% end %>
-        </div>
-        <% if current_user == @review.user %>
-          <div class="flex items-center justify-center gap-4">
-            <%= link_to t('reviews.edit.button'), edit_review_path, class: "btn btn-accent" %>
-            <%= link_to t('reviews.delete.button'), review_path(@review), class: "btn btn-error", data: { turbo_method: :delete, turbo_confirm: t('reviews.delete.delete_confirm') } %>
+            <div class="mt-5 mx-auto">
+              <%= link_to "https://twitter.com/share?url=#{post_review_url(@review)}&text=【#{@review.title}】%0a#{@review.product.brand.name}%20#{@review.product.name}のレビューをシェア%0a%0a%23インク沼%20%23iroGraphica%0a", title: "Xでシェア", class: "btn btn-neutral gap-0 w-[300px] sm:w-[350px]", target: :_blank, rel: "noopener noreferrer nofollow" do %>
+                <i class="fa-brands fa-x-twitter text-[24px]"></i></i><span class="text-[20px]">でシェア</span>
+              <% end %>
+            </div>
           </div>
-        <% end %>
+          <div class="lg:w-1/2 w-full lg:pl-10 lg:py-6 mt-6 lg:mt-0">
+            <h1 class="text-gray-900 text-3xl title-font font-medium mb-1"><%= @review.title %></h1>
+            <div class="flex">
+              <%= link_to user_path(@review.user), class: "flex items-center gap-2", data: { turbo_frame: "_top" } do %>
+                <% if @review.user.avatar.attached? %>
+                  <%= image_tag @review.user.avatar, class: "w-10 rounded-full border-[2px] border-gray-200" %>
+                <% else %>
+                  <%= image_tag 'kkrn_icon_user_1.png', class: "w-10 rounded-full border-[2px] border-gray-200" %>
+                <% end %>
+                <p><%= @review.user.name %></p>
+              <% end %>
+              <div class="flex ml-auto items-center justify-center text-[#959595]"><%= l(@review.created_at) %></div>
+            </div>
+            <div class="flex mb-4 mx-3 gap-2">
+              <%= render "reviews/like_btn", review: @review %>
+              <%= render "reviews/bookmark_btn", review: @review %>
+            </div>
+            <p class="leading-relaxed whitespace-pre-wrap"><%= @review.body %></p>
+            <div class="mt-6 items-center pb-5 border-t-2 border-gray-100 mb-5">
+              <%= link_to product_path(@review.product.id), class: "link text-[#3F51B5]", data: { turbo_frame: "_top" } do %>
+                <p><%= @review.product.brand.name %><%= @review.product.name %></p>
+              <% end %>
+              <p><%= t('reviews.show.using_paper') %><%= @review.paper %></p>
+              <p><%= t('reviews.show.using_pen') %><%= @review.pen %></p>
+              <% if @review.ink_recipes.present? %>
+                <p class="mt-2">インクレシピ</p>
+                <% @review.ink_recipes.each do |ink_recipe| %>
+                  <p><%= ink_recipe.name %>：<%= ink_recipe.amount %>ml</p>
+                <% end %>
+              <% end %>
+            </div>
+            <% if current_user == @review.user %>
+              <div class="flex items-center justify-center gap-4">
+                <%= link_to t('reviews.edit.button'), edit_review_path, class: "btn btn-accent", data: { turbo_frame: "_top" } %>
+                <%= link_to t('reviews.delete.button'), review_path(@review), class: "btn btn-error", data: { turbo_method: :delete, turbo_confirm: t('reviews.delete.delete_confirm') } %>
+              </div>
+            <% end %>
+          </div>
+        </div>
       </div>
-    </div>
-  </div>
-  <div class="text-center mt-5 mb-5">
-    <%= link_to t('helpers.links.back'), 'javascript:history.back()', class: "btn btn-outline btn-primary" %>
-  </div>
-</section>
+      <div class="text-center mt-5 mb-5">
+        <%= link_to t('helpers.links.back'), 'javascript:history.back()', class: "btn btn-outline btn-primary" %>
+      </div>
+    </section>
 
-<script>
-  var swiper = new Swiper(".mySwiper", {
-    loop: true,
-    spaceBetween: 10,
-    slidesPerView: 4,
-    freeMode: true,
-    watchSlidesProgress: true,
-  });
-  var swiper2 = new Swiper(".mySwiper2", {
-    loop: true,
-    spaceBetween: 10,
-    navigation: {
-      nextEl: ".swiper-button-next",
-      prevEl: ".swiper-button-prev",
-    },
-    thumbs: {
-      swiper: swiper,
-    },
-  });
-</script>
+    <script>
+      var swiper = new Swiper(".mySwiper", {
+        loop: true,
+        spaceBetween: 10,
+        slidesPerView: 4,
+        freeMode: true,
+        watchSlidesProgress: true,
+      });
+      var swiper2 = new Swiper(".mySwiper2", {
+        loop: true,
+        spaceBetween: 10,
+        navigation: {
+          nextEl: ".swiper-button-next",
+          prevEl: ".swiper-button-prev",
+        },
+        thumbs: {
+          swiper: swiper,
+        },
+      });
+    </script>
+  <% end %>
+<% else %>
+  <%= turbo_frame_tag "show_review", src: review_path(@review) do %>
+    <%= render "show_skeleton" %>
+  <% end %>
+<% end %>

--- a/app/views/shared/_loading.html.erb
+++ b/app/views/shared/_loading.html.erb
@@ -1,0 +1,5 @@
+<div data-loading-target="load" class="fixed inset-0 flex items-center justify-center bg-white bg-opacity-40">
+  <div class="h-[50px] w-[50px] flex items-center justify-center">
+    <span class="loading loading-dots loading-lg text-primary"></span>
+  </div>
+</div>

--- a/app/views/shared/_skeleton_card.html.erb
+++ b/app/views/shared/_skeleton_card.html.erb
@@ -1,0 +1,26 @@
+<div class="flex flex-wrap justify-center items-center p-5 gap-5">
+  <% 10.times do %>
+    <div class="card sm:card-side m-4 shadow">
+      <div class="px-10 sm:px-4 py-4 sm:relative">
+        <div class="skeleton h-[170px] w-[170px]"></div>
+        <div class="card-actions sm:justify-end mt-1">
+          <div class="skeleton h-4 w-20"></div>
+        </div>
+      </div>
+      <div class="card-body gap-2 flex-shrink-0 w-[250px] sm:w-[340px] p-4">
+        <div class="card-title overflow-hidden mb-1 justify-between">
+          <div class="skeleton h-4 w-full"></div>
+          <div class="skeleton h-8 w-8 shrink-0 rounded-full"></div>
+        </div>
+        <div class="skeleton h-4 w-28"></div>
+        <div class="skeleton h-4 w-28"></div>
+        <div class="skeleton h-4 w-full"></div>
+        <div class="skeleton h-4 w-full"></div>
+        <div class="skeleton h-4 w-full"></div>
+        <div class="card-actions justify-end">
+          <div class="skeleton h-[32px] w-[84px]"></div>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/static/home.html.erb
+++ b/app/views/static/home.html.erb
@@ -12,14 +12,32 @@
     <% end %>
   </div>
   <h1 class="text-[32px] sm:text-5xl font-bold text-center mb-10 tracking-wider"><%= t('home.see_review') %></h1>
-  <%= turbo_frame_tag "reviews" do %>
+  <%= turbo_frame_tag "reviews", src: reviews_path, loading: :lazy do %>
     <div class="flex flex-wrap justify-center items-center p-5 gap-5">
-      <% if @reviews.present? %>
-        <%= render partial: 'reviews/review', collection: @reviews %>
-      <% else %>
-        <div class="tracking-wider"><%= t('reviews.index.without_review') %></div>
+      <% 10.times do %>
+        <div class="card sm:card-side m-4 shadow">
+          <div class="px-10 sm:px-4 py-4 sm:relative">
+            <div class="skeleton h-[170px] w-[170px]"></div>
+            <div class="card-actions sm:justify-end mt-1">
+              <div class="skeleton h-4 w-20"></div>
+            </div>
+          </div>
+          <div class="card-body gap-2 flex-shrink-0 w-[250px] sm:w-[340px] p-4">
+            <div class="card-title overflow-hidden mb-1 justify-between">
+              <div class="skeleton h-4 w-full"></div>
+              <div class="skeleton h-8 w-8 shrink-0 rounded-full"></div>
+            </div>
+            <div class="skeleton h-4 w-28"></div>
+            <div class="skeleton h-4 w-28"></div>
+            <div class="skeleton h-4 w-full"></div>
+            <div class="skeleton h-4 w-full"></div>
+            <div class="skeleton h-4 w-full"></div>
+            <div class="card-actions justify-end">
+              <div class="skeleton h-[32px] w-[84px]"></div>
+            </div>
+          </div>
+        </div>
       <% end %>
     </div>
-    <%= render "shared/load_more_button" %>
   <% end %>
 </div>

--- a/app/views/static/home.html.erb
+++ b/app/views/static/home.html.erb
@@ -13,31 +13,6 @@
   </div>
   <h1 class="text-[32px] sm:text-5xl font-bold text-center mb-10 tracking-wider"><%= t('home.see_review') %></h1>
   <%= turbo_frame_tag "reviews", src: reviews_path, loading: :lazy do %>
-    <div class="flex flex-wrap justify-center items-center p-5 gap-5">
-      <% 10.times do %>
-        <div class="card sm:card-side m-4 shadow">
-          <div class="px-10 sm:px-4 py-4 sm:relative">
-            <div class="skeleton h-[170px] w-[170px]"></div>
-            <div class="card-actions sm:justify-end mt-1">
-              <div class="skeleton h-4 w-20"></div>
-            </div>
-          </div>
-          <div class="card-body gap-2 flex-shrink-0 w-[250px] sm:w-[340px] p-4">
-            <div class="card-title overflow-hidden mb-1 justify-between">
-              <div class="skeleton h-4 w-full"></div>
-              <div class="skeleton h-8 w-8 shrink-0 rounded-full"></div>
-            </div>
-            <div class="skeleton h-4 w-28"></div>
-            <div class="skeleton h-4 w-28"></div>
-            <div class="skeleton h-4 w-full"></div>
-            <div class="skeleton h-4 w-full"></div>
-            <div class="skeleton h-4 w-full"></div>
-            <div class="card-actions justify-end">
-              <div class="skeleton h-[32px] w-[84px]"></div>
-            </div>
-          </div>
-        </div>
-      <% end %>
-    </div>
+    <%= render "shared/skeleton_card" %>
   <% end %>
 </div>

--- a/app/views/users/_profile_header.html.erb
+++ b/app/views/users/_profile_header.html.erb
@@ -1,52 +1,60 @@
-<% if current_user == @user %>
-  <div class="flex justify-end">
-    <%= link_to t('users.show.edit_profile'), edit_user_registration_path, class: "btn btn-accent" %>
-  </div>
+<% if turbo_frame_request? %>
+  <%= turbo_frame_tag "profile_header" do %>
+    <% if current_user == @user %>
+      <div class="flex justify-end">
+        <%= link_to t('users.show.edit_profile'), edit_user_registration_path, class: "btn btn-accent" %>
+      </div>
+    <% end %>
+    <div class="lg:w-4/5 mx-auto flex flex-wrap items-center justify-center">
+      <div class="flex flex-col">
+        <% if @user.avatar.attached? %>
+          <%= image_tag @user.avatar, class: "object-cover w-[150px] rounded-full mx-10 border-[2px] border-gray-200" %>
+        <% else %>
+          <%= image_tag 'kkrn_icon_user_1.png', class: "w-[150px] rounded-full mx-10 border-[2px] border-gray-200" %>
+        <% end %>
+        <div class="mt-5 mx-auto items-center justify-center hidden sm:block">
+          <%= render 'x_share' %>
+        </div>
+        <% unless current_user == @user %>
+          <div class="mt-2 mx-auto items-center justify-center hidden sm:block">
+            <%= render 'follow_form', user: @user %>
+          </div>
+        <% end %>
+      </div>
+      <div class="mx-10 flex flex-col">
+        <span class="text-[36px] text-center"><%= @user.name %></span>
+        <%= render 'stats' %>
+        <p class="whitespace-pre-wrap"><%= @user.body %></p>
+        <div class="flex items-center gap-4 mt-6">
+          <% if @user.x_account.present? %>
+            <%= link_to @user.x_account do %>
+              <i class="fa-brands fa-square-x-twitter text-[24px]"></i>
+            <% end %>
+          <% end %>
+          <% if @user.instagram_account.present? %>
+            <%= link_to @user.instagram_account do %>
+              <i class="fa-brands fa-instagram text-[24px]"></i>
+            <% end %>
+          <% end %>
+          <% if @user.youtube_account.present? %>
+            <%= link_to @user.youtube_account do %>
+              <i class="fa-brands fa-youtube text-[24px]"></i>
+            <% end %>
+          <% end %>
+        </div>
+        <div class="mt-5 mx-auto items-center justify-center sm:hidden">
+          <%= render 'x_share' %>
+        </div>
+        <% unless current_user == @user %>
+          <div class="mt-2 mx-auto items-center justify-center sm:hidden">
+            <%= render 'follow_form', user: @user %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+<% else %>
+  <%= turbo_frame_tag "profile_header", src: user_path(@user) do %>
+    <%= render "profile_skeleton" %>
+  <% end %>
 <% end %>
-<div class="lg:w-4/5 mx-auto flex flex-wrap items-center justify-center">
-  <div class="flex flex-col">
-    <% if @user.avatar.attached? %>
-      <%= image_tag @user.avatar, class: "object-cover w-[150px] rounded-full mx-10 border-[2px] border-gray-200" %>
-    <% else %>
-      <%= image_tag 'kkrn_icon_user_1.png', class: "w-[150px] rounded-full mx-10 border-[2px] border-gray-200" %>
-    <% end %>
-    <div class="mt-5 mx-auto items-center justify-center hidden sm:block">
-      <%= render 'x_share' %>
-    </div>
-    <% unless current_user == @user %>
-      <div class="mt-2 mx-auto items-center justify-center hidden sm:block">
-        <%= render 'follow_form', user: @user %>
-      </div>
-    <% end %>
-  </div>
-  <div class="mx-10 flex flex-col">
-    <span class="text-[36px] text-center"><%= @user.name %></span>
-    <%= render 'stats' %>
-    <p class="whitespace-pre-wrap"><%= @user.body %></p>
-    <div class="flex items-center gap-4 mt-6">
-      <% if @user.x_account.present? %>
-        <%= link_to @user.x_account do %>
-          <i class="fa-brands fa-square-x-twitter text-[24px]"></i>
-        <% end %>
-      <% end %>
-      <% if @user.instagram_account.present? %>
-        <%= link_to @user.instagram_account do %>
-          <i class="fa-brands fa-instagram text-[24px]"></i>
-        <% end %>
-      <% end %>
-      <% if @user.youtube_account.present? %>
-        <%= link_to @user.youtube_account do %>
-          <i class="fa-brands fa-youtube text-[24px]"></i>
-        <% end %>
-      <% end %>
-    </div>
-    <div class="mt-5 mx-auto items-center justify-center sm:hidden">
-      <%= render 'x_share' %>
-    </div>
-    <% unless current_user == @user %>
-      <div class="mt-2 mx-auto items-center justify-center sm:hidden">
-        <%= render 'follow_form', user: @user %>
-      </div>
-    <% end %>
-  </div>
-</div>

--- a/app/views/users/_profile_header.html.erb
+++ b/app/views/users/_profile_header.html.erb
@@ -2,7 +2,7 @@
   <%= turbo_frame_tag "profile_header" do %>
     <% if current_user == @user %>
       <div class="flex justify-end">
-        <%= link_to t('users.show.edit_profile'), edit_user_registration_path, class: "btn btn-accent" %>
+        <%= link_to t('users.show.edit_profile'), edit_user_registration_path, class: "btn btn-accent", data: { turbo_frame: "_top" } %>
       </div>
     <% end %>
     <div class="lg:w-4/5 mx-auto flex flex-wrap items-center justify-center">

--- a/app/views/users/_profile_skeleton.html.erb
+++ b/app/views/users/_profile_skeleton.html.erb
@@ -1,0 +1,29 @@
+<div class="lg:w-4/5 mx-auto flex flex-wrap items-center justify-center">
+  <div class="flex flex-col">
+    <div class="skeleton h-[150px] w-[150px] shrink-0 rounded-full mx-10"></div>
+    <div class="mt-5 mx-auto items-center justify-center hidden sm:block">
+      <div class="skeleton h-[48px] w-[110px]"></div>
+    </div>
+    <div class="mt-2 mx-auto items-center justify-center hidden sm:block">
+      <div class="skeleton h-[48px] w-[110px]"></div>
+    </div>
+  </div>
+  <div class="mx-10 flex flex-col gap-2">
+    <div class="skeleton h-[54px] w-[210px]"></div>
+    <div class="skeleton h-4 w-28 mx-auto"></div>
+    <div class="skeleton h-4 w-full"></div>
+    <div class="skeleton h-4 w-full"></div>
+    <div class="skeleton h-4 w-full"></div>
+    <div class="flex items-center gap-4 mt-6">
+      <div class="skeleton h-[25px] w-[25px] shrink-0 rounded-full"></div>
+      <div class="skeleton h-[25px] w-[25px] shrink-0 rounded-full"></div>
+      <div class="skeleton h-[25px] w-[25px] shrink-0 rounded-full"></div>
+    </div>
+    <div class="mt-5 mx-auto items-center justify-center sm:hidden">
+      <div class="skeleton h-[48px] w-[110px]"></div>
+    </div>
+    <div class="mt-2 mx-auto items-center justify-center sm:hidden">
+      <div class="skeleton h-[48px] w-[110px]"></div>
+    </div>
+  </div>
+</div>

--- a/app/views/users/bookmarks.html.erb
+++ b/app/views/users/bookmarks.html.erb
@@ -4,12 +4,22 @@
     <div class="w-full mx-auto mt-5">
       <%= render "profile_tab" %>
     </div>
-    <div class="flex flex-wrap justify-center items-center p-5 gap-5">
-      <% if @bookmark_reviews.present? %>
-        <%= render partial: 'reviews/review', collection: @bookmark_reviews %>
-      <% else %>
-        <div><%= t('users.show.bookmark_not_found') %></div>
+    <% if turbo_frame_request? %>
+      <%= turbo_frame_tag "show_bookmark" do %>
+        <div class="flex flex-wrap justify-center items-center p-5 gap-5">
+          <% if @bookmark_reviews.present? %>
+            <%= render partial: 'reviews/review', collection: @bookmark_reviews %>
+          <% else %>
+            <div><%= t('users.show.bookmark_not_found') %></div>
+          <% end %>
+        </div>
       <% end %>
-    </div>
+    <% else %>
+      <%= turbo_frame_tag "show_bookmark", src: bookmarks_user_path(@user) do %>
+        <div class="flex flex-wrap justify-center items-center p-5 gap-5">
+          <%= render "shared/skeleton_card" %>
+        </div>
+      <% end %>
+    <% end %>
   </div>
 </section>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -4,13 +4,23 @@
     <div class="w-full mx-auto mt-5">
       <%= render "profile_tab" %>
     </div>
-    <div class="flex flex-wrap justify-center items-center p-5 gap-5">
-      <% if @reviews.present? %>
-        <%= render partial: 'reviews/review', collection: @reviews %>
-      <% else %>
-        <div><%= t('users.show.review_not_found') %></div>
+    <% if turbo_frame_request? %>
+      <%= turbo_frame_tag "show_collection" do %>
+        <div class="flex flex-wrap justify-center items-center p-5 gap-5">
+          <% if @reviews.present? %>
+            <%= render partial: 'reviews/review', collection: @reviews %>
+          <% else %>
+            <div><%= t('users.show.review_not_found') %></div>
+          <% end %>
+        </div>
       <% end %>
-    </div>
+    <% else %>
+      <%= turbo_frame_tag "show_collection", src: user_path(@user) do %>
+        <div class="flex flex-wrap justify-center items-center p-5 gap-5">
+          <%= render "shared/skeleton_card" %>
+        </div>
+      <% end %>
+    <% end %>
   </div>
   <%= turbo_frame_tag "remote_modal" %>
 </section>

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -35,7 +35,7 @@ module.exports = {
           "neutral-content": "#c9cbcf",
           "base-100": "#ffffff",
           "base-200": "#dedede",
-          "base-300": "#bebebe",
+          "base-300": "#e3e3e3",
           "base-content": "#161616",
           "info": "#7dd3fc",
           "info-content": "#051016",


### PR DESCRIPTION
# 実施タスク
closes #124 
ローディングアニメーションを実装

 # 実施内容
- home、reviews/show、products/show、プロフィール画面、検索結果にコンテンツの読み込みが終わるまでスケルトンスクリーンを表示させるようにしました。
  [![Image from Gyazo](https://i.gyazo.com/7723448a6f6ce3b4624a3ef326af4bac.gif)](https://gyazo.com/7723448a6f6ce3b4624a3ef326af4bac)
- レビュー投稿・編集画面、ユーザー新規登録画面、プロフィール編集画面、ログイン画面のsubmit時にローディングアニメーションを表示させるようにしました。
  [![Image from Gyazo](https://i.gyazo.com/937ab5930139fac8952ebfbeb968e773.gif)](https://gyazo.com/937ab5930139fac8952ebfbeb968e773)

# 備考
- スケルトンスクリーンをTurbo_frameの遅延読み込みで実装する都合上、homeのレビュー一覧表示を`reviews/index`を呼び出す形に変更しています。
- 現状、プロフィール画面のコレクションとブックマークで画面遷移が発生するため一度読み込んだ`profile_header`も再読み込みされてしまうため、コレクションとブックマークを行き来するたびに`profile_header`のスケルトンスクリーンも再表示されてしまいます。後日Turbo_frame化対応を行います。