### PR TITLE
動的OGPの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ end
 
 group :production do
   gem "aws-sdk-s3", "1.114.0", require: false
+  gem 'aws-sdk-cloudfront', '~> 1.118', require: false
 end
 
 gem "tailwindcss-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,9 @@ GEM
     ast (2.4.2)
     aws-eventstream (1.3.2)
     aws-partitions (1.1075.0)
+    aws-sdk-cloudfront (1.118.0)
+      aws-sdk-core (~> 3, >= 3.216.0)
+      aws-sigv4 (~> 1.5)
     aws-sdk-core (3.221.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
@@ -419,6 +422,7 @@ DEPENDENCIES
   active_storage_validations
   administrate
   administrate-field-active_storage
+  aws-sdk-cloudfront (~> 1.118)
   aws-sdk-s3 (= 1.114.0)
   bootsnap
   brakeman

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,13 +16,12 @@ module ApplicationHelper
         title: :title,
         description: :description,
         type: 'website',
-        url: 'https://irographica.com/',
+        url: request.original_url,
         image: image_url('irographica-staticOgp.png'),
         local: 'ja-JP'
       },
       twitter: {
         card: 'summary_large_image',
-        image: image_url('irographica-staticOgp.png')
       }
     }
   end

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -1,3 +1,5 @@
+<% set_meta_tags og: { title: @review.title } %>
+<% set_meta_tags og: { title: @review.title, image: request.base_url+rails_storage_proxy_path(@review.images.first) } if @review.images.attached? %>
 <% if turbo_frame_request? %>
   <%= turbo_frame_tag "show_review" do %>
     <section class="overflow-hidden">

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -1,5 +1,5 @@
 <% set_meta_tags og: { title: @review.title } %>
-<% set_meta_tags og: { title: @review.title, image: request.base_url+rails_storage_proxy_path(@review.images.first) } if @review.images.attached? %>
+<% set_meta_tags og: { title: @review.title, image: cdn_image_url(@review.images.first) } if @review.images.attached? %>
 <% if turbo_frame_request? %>
   <%= turbo_frame_tag "show_review" do %>
     <section class="overflow-hidden">

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -103,4 +103,5 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.action_controller.default_url_options = { host: "irographica.com" }
 end

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,0 +1,2 @@
+# S3の画像をデフォルトでCDN配信する設定
+Rails.application.config.active_storage.resolve_model_to_route = :cdn_image

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,2 +1,2 @@
 # S3の画像をデフォルトでプロキシモードで使用する用の設定
-Rails.application.config.active_storage.resolve_model_to_route = :rails_storage_proxy
+Rails.application.config.active_storage.resolve_model_to_route = :cdn_image

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,2 +1,2 @@
-# S3の画像をデフォルトでCDN配信する設定
-Rails.application.config.active_storage.resolve_model_to_route = :cdn_image
+# S3の画像をデフォルトでプロキシモードで使用する用の設定
+Rails.application.config.active_storage.resolve_model_to_route = :rails_storage_proxy

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,32 @@ Rails.application.routes.draw do
     resource :like, only: %i[create destroy]
     get :search, on: :collection
   end
+
+  direct :cdn_image do |model, options|
+    expires_in = options.delete(:expires_in) { ActiveStorage.urls_expire_in }
+
+    if model.respond_to?(:signed_id)
+      route_for(
+        :rails_service_blob_proxy,
+        model.signed_id(expires_in: expires_in),
+        model.filename,
+        options.merge(host: ENV["CDN_HOST"])
+      )
+    else
+      signed_blob_id = model.blob.signed_id(expires_in: expires_in)
+      variation_key  = model.variation.key
+      filename       = model.blob.filename
+
+      route_for(
+        :rails_blob_representation_proxy,
+        signed_blob_id,
+        variation_key,
+        filename,
+        options.merge(host: ENV["CDN_HOST"])
+      )
+    end
+  end
+
   resources :bookmarks, only: %i[create destroy]
   resources :notifications, only: :index
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,16 +24,17 @@ Rails.application.routes.draw do
     get :search, on: :collection
   end
 
+  # 画像をCDN配信する用のルーティング
   direct :cdn_image do |model, options|
     expires_in = options.delete(:expires_in) { ActiveStorage.urls_expire_in }
-    cdn_options = if Rails.env.development?
-                    Rails.application.routes.default_url_options
-                  else
+    cdn_options = if Rails.env.production?
                     {
                       protocol: 'https',
                       port: 443,
-                      host: Rails.env.production? ? "https://d2jjiem87n2bn7.cloudfront.net" : "#{Rails.env}.d2jjiem87n2bn7.cloudfront.net"
+                      host: ENV["CDN_HOST"]
                     }
+                  else
+                    Rails.application.routes.default_url_options
                   end
 
     if model.respond_to?(:signed_id)

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -13,6 +13,7 @@ amazon:
   secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
   region:            <%= ENV['AWS_REGION'] %>
   bucket:            <%= ENV['AWS_BUCKET'] %>
+  public: true
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -13,7 +13,6 @@ amazon:
   secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
   region:            <%= ENV['AWS_REGION'] %>
   bucket:            <%= ENV['AWS_BUCKET'] %>
-  public: true
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:


### PR DESCRIPTION
# 実施タスク
closes #127 
動的OGPの実装

# 実施内容
- 動的OGPを実装しました。
- 画像をCloudfrontから配信するようにしました。

# 備考
- 動的OGPについて、当初はレビューの1枚目の画像にレビューのタイトルを表示しようと考えましたが、背景となる画像が見にくくなるため画像のみ表示する形にしました。
- ActiveStorageからOGP画像を配信するにはプロキシモードを使用する必要があるため、CDNから配信する形にしました。