### PR TITLE
レビュー検索機能が機能していなかった問題等を修正

### DIFF
--- a/app/views/reviews/search.html.erb
+++ b/app/views/reviews/search.html.erb
@@ -12,7 +12,7 @@
       <%= render "shared/load_more_button" %>
     <% end %>
   <% else %>
-    <%= turbo_frame_tag "search_reviews", src: search_reviews_path do %>
+    <%= turbo_frame_tag "search_reviews", src: search_reviews_path(q: params[:q], c: params[:c]) do %>
       <%= render "shared/skeleton_card" %>
     <% end %>
   <% end %>

--- a/app/views/shared/_search_tab.html.erb
+++ b/app/views/shared/_search_tab.html.erb
@@ -15,11 +15,7 @@
   <%= t('search.result')%>
 </p>
 <p class="text-center">
-  <% if request.path.include?("reviews") %>
-    <%= @reviews.count %>件
-  <% else %>
-    <%= @products.count %>件
-  <% end %>
+  <%= @pagy.count %>件
 </p>
 <div class="font-medium text-center text-gray-500 border-b border-gray-200 dark:text-gray-400 dark:border-gray-700 sm:w-1/2 mx-auto mb-5">
   <ul class="flex flex-wrap justify-center items-center -mb-px">


### PR DESCRIPTION
# 実施タスク
- 検索した際、レビューの検索結果のみ機能せず、投稿されたすべてのレビューが表示される問題の修正
- 検索結果の件数が、全件数ではなくページネーションの件数になっている問題の修正

# 実施内容
- 検索した際、レビューの検索結果のみ機能せず、投稿されたすべてのレビューが表示される問題を修正しました
- 検索結果の件数が、全件数ではなくページネーションの件数になっている問題を修正しました

# 備考
- スケルトンスクリーン表示のためにTurbo_frameの遅延読み込みを使っていましたが、`src`に`search_reviews_path`のみ設定し、検索ワード（`q: params[:q], c: params[:c]`）を渡していなかったために、検索ワードなしで検索した際の結果がTurbo_frame内にレンダリングされてしまっていました。`search_reviews_path(q: params[:q], c: params[:c])`に修正することで、期待通りの結果が出力されるようになりました。
- すべての検索結果が`@reviews``@products`から`@pagy`に格納されるようになっていたので、`@pagy.count`で全件数取得する形に修正しました。