### PR TITLE
fix: scope範囲で余計なものも指定していたので削除

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -274,7 +274,7 @@ Devise.setup do |config|
   config.omniauth :twitter2,
                   Rails.env.production? ? ENV["TWITTER_CLIENT_ID"] : Rails.application.credentials.dig(:twitter, :TWITTER_CLIENT_ID),
                   Rails.env.production? ? ENV["TWITTER_CLIENT_SECRET"] : Rails.application.credentials.dig(:twitter, :TWITTER_CLIENT_SECRET),
-                  callback_path: "/users/auth/twitter2/callback", scope: "tweet.read users.read offline.access"
+                  callback_path: "/users/auth/twitter2/callback", scope: "tweet.read users.read"
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or


### PR DESCRIPTION
# 実施タスク
Xのscopeで余計なものを指定していたので削除

# 実施内容
scopeを必要なもののみにしました。

# 備考
Xのユーザー情報をとってくるscopeは`tweet.read`と`users.read`のみでよかったようなので`offline.access`を削除しました。
参考: https://devcommunity.x.com/t/accessing-2-users-me-through-oauth-2-0-returns-403/188988